### PR TITLE
[AIR-51] JWT 로그인 API 구현

### DIFF
--- a/aircnc/build.gradle
+++ b/aircnc/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/SecurityConfig.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/SecurityConfig.java
@@ -1,26 +1,90 @@
 package com.gurudev.aircnc.configuration;
 
+import com.gurudev.aircnc.configuration.jwt.Jwt;
+import com.gurudev.aircnc.configuration.jwt.JwtAuthenticationFilter;
+import com.gurudev.aircnc.configuration.jwt.JwtAuthenticationProvider;
+import com.gurudev.aircnc.configuration.jwt.JwtConfigure;
+import com.gurudev.aircnc.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+@RequiredArgsConstructor
+public class SecurityConfig{
+
+  private final JwtConfigure jwtConfigure;
+  private final ApplicationContext applicationContext;
 
   @Bean
   PasswordEncoder passwordEncoder() {
     return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
-    // TODO : CORS
-    http.authorizeRequests(request -> request.anyRequest().permitAll())
-        .csrf().disable();
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    final JwtAuthenticationProvider jwtAuthenticationProvider = applicationContext.getBean(
+        JwtAuthenticationProvider.class);
+
+    http
+        .formLogin().disable()
+        .csrf().disable()
+        .headers().disable()
+        .httpBasic().disable()
+        .rememberMe().disable()
+        .logout().disable()
+        .sessionManagement()
+        .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+    http.getSharedObject(AuthenticationManagerBuilder.class)
+        .authenticationProvider(jwtAuthenticationProvider);
+
+    http
+        .authorizeHttpRequests()
+        .antMatchers("/api/v1/members", "/api/v1/login").permitAll()
+        .anyRequest().authenticated();
+
+    http.addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class);
+
+    return http.build();
+  }
+
+
+  public JwtAuthenticationFilter jwtAuthenticationFilter() {
+    final Jwt jwt = applicationContext.getBean(Jwt.class);
+    return new JwtAuthenticationFilter(jwtConfigure.getHeader(), jwt);
+  }
+
+  @Bean
+  public Jwt jwt() {
+    return new Jwt(
+        jwtConfigure.getIssuer(),
+        jwtConfigure.getClientSecret(),
+        jwtConfigure.getExpirySeconds()
+    );
+  }
+
+  @Bean
+  public JwtAuthenticationProvider jwtAuthenticationProvider(MemberService memberService, Jwt jwt) {
+    return new JwtAuthenticationProvider(jwt, memberService);
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(
+      AuthenticationConfiguration authenticationConfiguration) throws Exception {
+    return authenticationConfiguration.getAuthenticationManager();
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/SecurityConfig.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/SecurityConfig.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/SecurityConfig.java
@@ -51,10 +51,10 @@ public class SecurityConfig{
     http.getSharedObject(AuthenticationManagerBuilder.class)
         .authenticationProvider(jwtAuthenticationProvider);
 
-    http
-        .authorizeHttpRequests()
-        .antMatchers("/api/v1/members", "/api/v1/login").permitAll()
-        .anyRequest().authenticated();
+//    http
+//        .authorizeHttpRequests()
+//        .antMatchers("/api/v1/members", "/api/v1/login").permitAll()
+//        .anyRequest().authenticated();
 
     http.addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class);
 

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/SecurityConfig.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/SecurityConfig.java
@@ -51,9 +51,10 @@ public class SecurityConfig{
     http.getSharedObject(AuthenticationManagerBuilder.class)
         .authenticationProvider(jwtAuthenticationProvider);
 
-//    http
-//        .authorizeHttpRequests()
-//        .antMatchers("/api/v1/members", "/api/v1/login").permitAll()
+    // 개발 중
+    http
+        .authorizeHttpRequests()
+        .antMatchers("/api/v1/members", "/api/v1/login").permitAll();
 //        .anyRequest().authenticated();
 
     http.addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class);

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/Jwt.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/Jwt.java
@@ -1,0 +1,124 @@
+package com.gurudev.aircnc.configuration.jwt;
+
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class Jwt {
+
+  private final String issuer;
+  private final String clientSecret;
+  private final int expirySeconds;
+  private final Algorithm algorithm;
+  private final JWTVerifier jwtVerifier;
+
+  public Jwt(String issuer, String clientSecret, int expirySeconds) {
+    this.issuer = issuer;
+    this.clientSecret = clientSecret;
+    this.expirySeconds = expirySeconds;
+    this.algorithm = Algorithm.HMAC512(clientSecret);
+    this.jwtVerifier = com.auth0.jwt.JWT.require(algorithm)
+        .withIssuer(issuer)
+        .build();
+  }
+
+  public String sign(Claims claims) {
+    Date now = new Date();
+    JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
+    builder.withIssuer(issuer);
+    builder.withIssuedAt(now);
+    if (expirySeconds > 0) {
+      builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
+    }
+    builder.withClaim("username", claims.username);
+    builder.withArrayClaim("roles", claims.roles);
+    return builder.sign(algorithm);
+  }
+
+  public Claims verify(String token) throws JWTVerificationException {
+    return new Claims(jwtVerifier.verify(token));
+  }
+
+  public String getIssuer() {
+    return issuer;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public int getExpirySeconds() {
+    return expirySeconds;
+  }
+
+  public Algorithm getAlgorithm() {
+    return algorithm;
+  }
+
+  public JWTVerifier getJwtVerifier() {
+    return jwtVerifier;
+  }
+
+  static public class Claims {
+
+    String username;
+    String[] roles;
+    Date iat;
+    Date exp;
+
+    private Claims() {/*no-op*/}
+
+    Claims(DecodedJWT decodedJWT) {
+      Claim username = decodedJWT.getClaim("username");
+      if (!username.isNull()) {
+        this.username = username.asString();
+      }
+      Claim roles = decodedJWT.getClaim("roles");
+      if (!roles.isNull()) {
+        this.roles = roles.asArray(String.class);
+      }
+      this.iat = decodedJWT.getIssuedAt();
+      this.exp = decodedJWT.getExpiresAt();
+    }
+
+    public static Claims from(String username, String[] roles) {
+      Claims claims = new Claims();
+      claims.username = username;
+      claims.roles = roles;
+      return claims;
+    }
+
+    public Map<String, Object> asMap() {
+      Map<String, Object> map = new HashMap<>();
+      map.put("username", username);
+      map.put("roles", roles);
+      map.put("iat", iat());
+      map.put("exp", exp());
+      return map;
+    }
+
+    long iat() {
+      return iat != null ? iat.getTime() : -1;
+    }
+
+    long exp() {
+      return exp != null ? exp.getTime() : -1;
+    }
+
+    void eraseIat() {
+      iat = null;
+    }
+
+    void eraseExp() {
+      exp = null;
+    }
+
+  }
+
+}

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/Jwt.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/Jwt.java
@@ -95,7 +95,10 @@ public final class Jwt {
     }
 
     public Map<String, Object> asMap() {
-      return Map.of("username", username, "roles", roles, "iat", iat(), "exp", exp());
+      return Map.of("username", username,
+                    "roles", roles,
+                    "iat", iat(),
+                    "exp", exp());
     }
 
     long iat() {

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/Jwt.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/Jwt.java
@@ -34,7 +34,7 @@ public final class Jwt {
     builder.withIssuer(issuer);
     builder.withIssuedAt(now);
     if (expirySeconds > 0) {
-      builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
+      builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1000));
     }
     builder.withClaim("username", claims.username);
     builder.withArrayClaim("roles", claims.roles);
@@ -65,7 +65,7 @@ public final class Jwt {
     return jwtVerifier;
   }
 
-  static public class Claims {
+  public static class Claims {
 
     String username;
     String[] roles;
@@ -95,12 +95,7 @@ public final class Jwt {
     }
 
     public Map<String, Object> asMap() {
-      Map<String, Object> map = new HashMap<>();
-      map.put("username", username);
-      map.put("roles", roles);
-      map.put("iat", iat());
-      map.put("exp", exp());
-      return map;
+      return Map.of("username", username, "roles", roles, "iat", iat(), "exp", exp());
     }
 
     long iat() {

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthentication.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthentication.java
@@ -1,0 +1,19 @@
+package com.gurudev.aircnc.configuration.jwt;
+
+import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
+import static org.springframework.util.StringUtils.hasText;
+
+public class JwtAuthentication {
+  public final String token;
+
+  public final String username;
+
+  JwtAuthentication(String token, String username) {
+    checkArgument(hasText(token), "token must be provided.");
+    checkArgument(hasText(username), "username must be provided.");
+
+    this.token = token;
+    this.username = username;
+  }
+
+}

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthentication.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthentication.java
@@ -9,7 +9,7 @@ public class JwtAuthentication {
   public final String email;
 
   JwtAuthentication(String token, String email) {
-    checkArgument(hasText(token), "토큰은 null일 수 없습니다.");
+    checkArgument(hasText(token), "토큰은 null 일 수 없습니다.");
     checkArgument(hasText(email), "이메일은 null 일 수 없습니다.");
 
     this.token = token;

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthentication.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthentication.java
@@ -4,16 +4,16 @@ import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
 import static org.springframework.util.StringUtils.hasText;
 
 public class JwtAuthentication {
+
   public final String token;
+  public final String email;
 
-  public final String username;
-
-  JwtAuthentication(String token, String username) {
-    checkArgument(hasText(token), "token must be provided.");
-    checkArgument(hasText(username), "username must be provided.");
+  JwtAuthentication(String token, String email) {
+    checkArgument(hasText(token), "토큰은 null일 수 없습니다.");
+    checkArgument(hasText(email), "이메일은 null 일 수 없습니다.");
 
     this.token = token;
-    this.username = username;
+    this.email = email;
   }
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthenticationFilter.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,94 @@
+package com.gurudev.aircnc.configuration.jwt;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.springframework.util.StringUtils.hasText;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+  private final String headerKey;
+  private final Jwt jwt;
+
+  public JwtAuthenticationFilter(String headerKey, Jwt jwt) {
+    this.headerKey = headerKey;
+    this.jwt = jwt;
+  }
+
+  @Override
+  public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletRequest request = (HttpServletRequest) req;
+    HttpServletResponse response = (HttpServletResponse) res;
+
+    if (SecurityContextHolder.getContext().getAuthentication() == null) {
+      String token = getToken(request);
+      if (token != null) {
+        try {
+          Jwt.Claims claims = verify(token);
+          log.debug("Jwt parse result: {}", claims);
+
+          String username = claims.username;
+          List<GrantedAuthority> authorities = getAuthorities(claims);
+
+          if (hasText(username) && authorities.size() > 0) {
+            JwtAuthenticationToken authentication =
+                new JwtAuthenticationToken(new JwtAuthentication(token, username), null, authorities);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+          }
+        } catch (Exception e) {
+          log.warn("Jwt processing failed: {}", e.getMessage());
+        }
+      }
+    } else {
+      log.debug("SecurityContextHolder not populated with security token, as it already contained: '{}'",
+          SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  private String getToken(HttpServletRequest request) {
+    String token = request.getHeader(headerKey);
+    if (hasText(token)) {
+      log.debug("Jwt authorization api detected: {}", token);
+      try {
+        return URLDecoder.decode(token, "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        log.error(e.getMessage(), e);
+      }
+    }
+    return null;
+  }
+
+  private Jwt.Claims verify(String token) {
+    return jwt.verify(token);
+  }
+
+  private List<GrantedAuthority> getAuthorities(Jwt.Claims claims) {
+    String[] roles = claims.roles;
+    return roles == null || roles.length == 0 ?
+        emptyList() :
+        Arrays.stream(roles).map(SimpleGrantedAuthority::new).collect(toList());
+  }
+
+}

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthenticationProvider.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,67 @@
+package com.gurudev.aircnc.configuration.jwt;
+
+import static org.springframework.util.TypeUtils.isAssignable;
+
+import com.gurudev.aircnc.domain.member.entity.Email;
+import com.gurudev.aircnc.domain.member.entity.Member;
+import com.gurudev.aircnc.domain.member.entity.Password;
+import com.gurudev.aircnc.domain.member.service.MemberService;
+import java.util.List;
+import org.springframework.dao.DataAccessException;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+  private final Jwt jwt;
+  private final MemberService memberService;
+
+  public JwtAuthenticationProvider(Jwt jwt, MemberService memberService) {
+    this.jwt = jwt;
+    this.memberService = memberService;
+  }
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    JwtAuthenticationToken jwtAuthentication = (JwtAuthenticationToken) authentication;
+    return processUserAuthentication(
+        String.valueOf(jwtAuthentication.getPrincipal()),
+        jwtAuthentication.getCredentials()
+    );
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return isAssignable(JwtAuthenticationToken.class, authentication);
+  }
+
+  private Authentication processUserAuthentication(String principal, String credentials) {
+    try {
+      Member member = memberService.login(new Email(principal), new Password(credentials));
+      List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(member.getRole().name()));
+      String token = getToken(Email.toString(member.getEmail()), authorities);
+      JwtAuthenticationToken authenticated =
+          new JwtAuthenticationToken(
+              new JwtAuthentication(token, Email.toString(member.getEmail())), null,
+              authorities);
+      authenticated.setDetails(member);
+      return authenticated;
+    } catch (IllegalArgumentException e) {
+      throw new BadCredentialsException(e.getMessage());
+    } catch (DataAccessException e) {
+      throw new AuthenticationServiceException(e.getMessage(), e);
+    }
+  }
+
+  private String getToken(final String username, final List<GrantedAuthority> authorities) {
+    String[] roles = authorities.stream()
+        .map(GrantedAuthority::getAuthority)
+        .toArray(String[]::new);
+    return jwt.sign(Jwt.Claims.from(username, roles));
+  }
+}

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthenticationToken.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,51 @@
+package com.gurudev.aircnc.configuration.jwt;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+  private final Object principal;
+
+  private String credentials;
+
+  public JwtAuthenticationToken(String principal, String credentials) {
+    super(null);
+    super.setAuthenticated(false);
+
+    this.principal = principal;
+    this.credentials = credentials;
+  }
+
+  JwtAuthenticationToken(Object principal, String credentials, Collection<? extends GrantedAuthority> authorities) {
+    super(authorities);
+    super.setAuthenticated(true);
+
+    this.principal = principal;
+    this.credentials = credentials;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return principal;
+  }
+
+  @Override
+  public String getCredentials() {
+    return credentials;
+  }
+
+  public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+    if (isAuthenticated) {
+      throw new IllegalArgumentException("Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead");
+    }
+    super.setAuthenticated(false);
+  }
+
+  @Override
+  public void eraseCredentials() {
+    super.eraseCredentials();
+    credentials = null;
+  }
+
+}

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtConfigure.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtConfigure.java
@@ -1,0 +1,20 @@
+package com.gurudev.aircnc.configuration.jwt;
+
+import lombok.Getter;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+//@Setter
+//@EnableConfigurationProperties
+//@ConfigurationProperties(prefix = "jwt")
+public class JwtConfigure {
+
+  private String header = "token";
+
+  private String issuer = "gurudev";
+
+  private String clientSecret = "EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ";
+
+  private int expirySeconds = 60;
+}

--- a/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtConfigure.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/configuration/jwt/JwtConfigure.java
@@ -1,20 +1,21 @@
 package com.gurudev.aircnc.configuration.jwt;
 
 import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @Getter
-//@Setter
-//@EnableConfigurationProperties
-//@ConfigurationProperties(prefix = "jwt")
+@Setter
+@ConfigurationProperties(prefix = "jwt")
 public class JwtConfigure {
 
-  private String header = "token";
+  private String header;
 
-  private String issuer = "gurudev";
+  private String issuer;
 
-  private String clientSecret = "EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ";
+  private String clientSecret;
 
-  private int expirySeconds = 60;
+  private int expirySeconds;
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/controller/MemberController.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/controller/MemberController.java
@@ -3,11 +3,18 @@ package com.gurudev.aircnc.controller;
 import static com.gurudev.aircnc.controller.dto.MemberDto.MemberResponse;
 import static com.gurudev.aircnc.controller.dto.MemberDto.MemberRegisterRequest;
 
+import com.gurudev.aircnc.configuration.jwt.JwtAuthentication;
+import com.gurudev.aircnc.configuration.jwt.JwtAuthenticationToken;
+import com.gurudev.aircnc.controller.dto.MemberDto.MemberLoginRequest;
+import com.gurudev.aircnc.controller.dto.MemberDto.MemberLoginRequest.Request;
+import com.gurudev.aircnc.controller.dto.MemberDto.MemberTokenResponse;
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,12 +26,30 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
   private final MemberService memberService;
+  private final AuthenticationManager authenticationManager;
 
   @PostMapping("/members")
-  public ResponseEntity<MemberResponse> registerMember(@RequestBody MemberRegisterRequest memberDto) {
+  public ResponseEntity<MemberResponse> registerMember(
+      @RequestBody MemberRegisterRequest memberDto) {
     Member registeredMember = memberService.register(memberDto.toEntity());
 
     return new ResponseEntity<>(MemberResponse.of(registeredMember), HttpStatus.CREATED);
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<MemberTokenResponse> login(@RequestBody MemberLoginRequest request) {
+    final Request loginRequest = request.getRequest();
+    System.out.println(loginRequest.getEmail());
+    System.out.println(loginRequest.getPassword());
+
+    final JwtAuthenticationToken authToken =
+        new JwtAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword());
+    final Authentication resultToken = authenticationManager.authenticate(authToken);
+    final JwtAuthenticationToken authenticated = (JwtAuthenticationToken) resultToken;
+    final JwtAuthentication principal = (JwtAuthentication) authenticated.getPrincipal();
+    final Member member = (Member) authenticated.getDetails();
+
+    return new ResponseEntity<>(MemberTokenResponse.of(member, principal.token), HttpStatus.OK);
   }
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/controller/MemberController.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/controller/MemberController.java
@@ -5,9 +5,9 @@ import static com.gurudev.aircnc.controller.dto.MemberDto.MemberRegisterRequest;
 
 import com.gurudev.aircnc.configuration.jwt.JwtAuthentication;
 import com.gurudev.aircnc.configuration.jwt.JwtAuthenticationToken;
-import com.gurudev.aircnc.controller.dto.MemberDto.MemberLoginRequest;
-import com.gurudev.aircnc.controller.dto.MemberDto.MemberLoginRequest.Request;
-import com.gurudev.aircnc.controller.dto.MemberDto.MemberTokenResponse;
+import com.gurudev.aircnc.controller.dto.MemberDto.LoginRequest;
+import com.gurudev.aircnc.controller.dto.MemberDto.LoginRequest.Request;
+import com.gurudev.aircnc.controller.dto.MemberDto.LoginResponse;
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -37,19 +37,17 @@ public class MemberController {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<MemberTokenResponse> login(@RequestBody MemberLoginRequest request) {
-    final Request loginRequest = request.getRequest();
-    System.out.println(loginRequest.getEmail());
-    System.out.println(loginRequest.getPassword());
+  public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+    Request loginRequest = request.getRequest();
 
-    final JwtAuthenticationToken authToken =
+    JwtAuthenticationToken authToken =
         new JwtAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword());
-    final Authentication resultToken = authenticationManager.authenticate(authToken);
-    final JwtAuthenticationToken authenticated = (JwtAuthenticationToken) resultToken;
-    final JwtAuthentication principal = (JwtAuthentication) authenticated.getPrincipal();
-    final Member member = (Member) authenticated.getDetails();
+    Authentication resultToken = authenticationManager.authenticate(authToken);
+    JwtAuthenticationToken authenticated = (JwtAuthenticationToken) resultToken;
+    JwtAuthentication principal = (JwtAuthentication) authenticated.getPrincipal();
+    Member member = (Member) authenticated.getDetails();
 
-    return new ResponseEntity<>(MemberTokenResponse.of(member, principal.token), HttpStatus.OK);
+    return ResponseEntity.ok(LoginResponse.of(member, principal.token));
   }
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/controller/dto/MemberDto.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/controller/dto/MemberDto.java
@@ -46,6 +46,28 @@ public class MemberDto {
     }
   }
 
+  @Getter
+  public static class MemberLoginRequest {
+
+    @JsonProperty("member")
+    private Request request;
+
+    @Getter
+    public static class Request {
+
+      private String email;
+      private String password;
+
+      public String getEmail(){
+        return this.email;
+      }
+
+      public String getPassword(){
+        return this.password;
+      }
+    }
+  }
+
 
   @Getter
   @RequiredArgsConstructor(access = PRIVATE)
@@ -84,6 +106,44 @@ public class MemberDto {
             .email(Email.toString(member.getEmail()))
             .phoneNumber(PhoneNumber.toString(member.getPhoneNumber()))
             .role(member.getRole())
+            .build();
+      }
+    }
+  }
+
+  @Getter
+  @RequiredArgsConstructor(access = PRIVATE)
+  public static class MemberTokenResponse {
+
+    @JsonProperty("member")
+    private final Response response;
+
+    public static MemberTokenResponse of(Member member, String token) {
+      return new MemberTokenResponse(Response.of(member, token));
+    }
+
+    @Getter
+    public static class Response {
+
+      private final String email;
+      private final String name;
+      private final String role;
+      private final String token;
+
+      @Builder(access = PRIVATE)
+      private Response(String email, String name, Role role, String token) {
+        this.email = email;
+        this.name = name;
+        this.role = role.name();
+        this.token = token;
+      }
+
+      public static Response of(Member member, String token) {
+        return Response.builder()
+            .email(Email.toString(member.getEmail()))
+            .name(member.getName())
+            .role(member.getRole())
+            .token(token)
             .build();
       }
     }

--- a/aircnc/src/main/java/com/gurudev/aircnc/controller/dto/MemberDto.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/controller/dto/MemberDto.java
@@ -47,7 +47,7 @@ public class MemberDto {
   }
 
   @Getter
-  public static class MemberLoginRequest {
+  public static class LoginRequest {
 
     @JsonProperty("member")
     private Request request;
@@ -113,13 +113,13 @@ public class MemberDto {
 
   @Getter
   @RequiredArgsConstructor(access = PRIVATE)
-  public static class MemberTokenResponse {
+  public static class LoginResponse {
 
     @JsonProperty("member")
     private final Response response;
 
-    public static MemberTokenResponse of(Member member, String token) {
-      return new MemberTokenResponse(Response.of(member, token));
+    public static LoginResponse of(Member member, String token) {
+      return new LoginResponse(Response.of(member, token));
     }
 
     @Getter

--- a/aircnc/src/main/resources/application.yaml
+++ b/aircnc/src/main/resources/application.yaml
@@ -15,5 +15,11 @@ spring:
         format_sql: true
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
 
+jwt:
+  header: "token"
+  issuer: "gurudev"
+  client-secret: "EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ"
+  expiry-seconds: 60
+
 room-photos:
   path: src/main/resources/room-photos/dest/

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/BasicControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/BasicControllerTest.java
@@ -1,19 +1,81 @@
 package com.gurudev.aircnc.controller;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public abstract class BasicControllerTest {
+public class BasicControllerTest {
 
+  protected static String token;
   @Autowired
   protected MockMvc mockMvc;
 
   protected ObjectMapper objectMapper = new ObjectMapper();
 
+  @BeforeEach
+  void setUp() {
+    유저_등록("guest@naver.com", "guest1234!", "guest", "GUEST");
+    유저_등록("host@naver.com", "host1234!", "host", "HOST");
+  }
 
+  protected void 유저_등록(String email, String password, String name, String role) {
+    try {
+      ObjectNode objectNode = objectMapper.createObjectNode();
+      ObjectNode member = objectNode.putObject("member");
+      member.put("email", email)
+          .put("password", password)
+          .put("name", name)
+          .put("birthDate", "1998-04-21") // random date
+          .put("phoneNumber", "010-1234-5678") // random number
+          .put("role", role);
+
+      mockMvc.perform(post("/api/v1/members")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectNode.toString()))
+          .andExpect(status().isCreated());
+    } catch (Exception e) {
+      throw new RuntimeException("테스트 멤버 등록 실패입니다.");
+    }
+  }
+
+
+  protected void 로그인(String email, String password) {
+    try {
+      ObjectNode objectNode = objectMapper.createObjectNode();
+      ObjectNode member = objectNode.putObject("member");
+      member.put("email", email)
+          .put("password", password);
+
+      MockHttpServletResponse response = mockMvc.perform(post("/api/v1/login")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectNode.toString()))
+          .andExpect(status().isOk())
+          .andReturn().getResponse();
+
+      token = objectMapper.readValue(response.getContentAsString(),
+          JsonNode.class).get("member").get("token").asText();
+
+      assertThat(token).isNotNull();
+
+    } catch (Exception e) {
+      throw new RuntimeException("테스트 멤버 로그인 실패입니다.");
+    }
+  }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/BasicControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/BasicControllerTest.java
@@ -1,25 +1,24 @@
 package com.gurudev.aircnc.controller;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.assertj.core.api.Assertions;
+import com.gurudev.aircnc.exception.AircncRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Transactional
 @AutoConfigureMockMvc
 public class BasicControllerTest {
 
@@ -31,14 +30,14 @@ public class BasicControllerTest {
 
   @BeforeEach
   void setUp() {
-    유저_등록("guest@naver.com", "guest1234!", "guest", "GUEST");
-    유저_등록("host@naver.com", "host1234!", "host", "HOST");
+    멤버_등록("guest@naver.com", "guest1234!", "guest", "GUEST");
+    멤버_등록("host@naver.com", "host1234!", "host", "HOST");
   }
 
-  protected void 유저_등록(String email, String password, String name, String role) {
+  protected void 멤버_등록(String email, String password, String name, String role) {
     try {
-      ObjectNode objectNode = objectMapper.createObjectNode();
-      ObjectNode member = objectNode.putObject("member");
+      ObjectNode memberRegisterRequest = objectMapper.createObjectNode();
+      ObjectNode member = memberRegisterRequest.putObject("member");
       member.put("email", email)
           .put("password", password)
           .put("name", name)
@@ -48,24 +47,24 @@ public class BasicControllerTest {
 
       mockMvc.perform(post("/api/v1/members")
               .contentType(MediaType.APPLICATION_JSON)
-              .content(objectNode.toString()))
+              .content(memberRegisterRequest.toString()))
           .andExpect(status().isCreated());
     } catch (Exception e) {
-      throw new RuntimeException("테스트 멤버 등록 실패입니다.");
+      throw new AircncRuntimeException("테스트 멤버 등록 실패입니다.");
     }
   }
 
 
   protected void 로그인(String email, String password) {
     try {
-      ObjectNode objectNode = objectMapper.createObjectNode();
-      ObjectNode member = objectNode.putObject("member");
+      ObjectNode loginRequest = objectMapper.createObjectNode();
+      ObjectNode member = loginRequest.putObject("member");
       member.put("email", email)
           .put("password", password);
 
       MockHttpServletResponse response = mockMvc.perform(post("/api/v1/login")
               .contentType(MediaType.APPLICATION_JSON)
-              .content(objectNode.toString()))
+              .content(loginRequest.toString()))
           .andExpect(status().isOk())
           .andReturn().getResponse();
 
@@ -75,7 +74,7 @@ public class BasicControllerTest {
       assertThat(token).isNotNull();
 
     } catch (Exception e) {
-      throw new RuntimeException("테스트 멤버 로그인 실패입니다.");
+      throw new AircncRuntimeException("테스트 멤버 로그인 실패입니다.");
     }
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
@@ -32,4 +32,44 @@ class MemberControllerTest extends BasicControllerTest {
         .andExpect(jsonPath("$.member.phoneNumber").value("010-1234-5678"))
         .andExpect(jsonPath("$.member.role").value("GUEST"));
   }
+
+  @Test
+  void 로그인_API() throws Exception {
+    // 로그인
+    ObjectNode objectNode = objectMapper.createObjectNode();
+    ObjectNode member = objectNode.putObject("member");
+    member.put("email", "seunghan@gamil.com")
+        .put("password", "pass12343")
+        .put("name", "seunghan")
+        .put("birthDate", "1998-04-21")
+        .put("phoneNumber", "010-1234-5678")
+        .put("role", "GUEST");
+
+    mockMvc.perform(post("/api/v1/members")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectNode.toString()))
+        .andExpect(status().isCreated());
+
+    ObjectNode objectNode2 = objectMapper.createObjectNode();
+
+    String email = "seunghan@gamil.com";
+    String password = "pass12343";
+    String name = "seunghan";
+
+    ObjectNode loginMember = objectNode2.putObject("member");
+    loginMember.put("email", email)
+        .put("password", password);
+
+    mockMvc.perform(post("/api/v1/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectNode2.toString()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.member.email").value(email))
+        .andExpect(jsonPath("$.member.name").value(name))
+        .andExpect(jsonPath("$.member.role").value("GUEST"))
+        .andExpect(jsonPath("$.member.token").exists());
+
+  }
+
+
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
@@ -10,13 +10,12 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
 
-@Transactional
 class MemberControllerTest extends BasicControllerTest {
 
   @Test
   void 회원가입_API() throws Exception {
-    ObjectNode objectNode = objectMapper.createObjectNode();
-    ObjectNode member = objectNode.putObject("member");
+    ObjectNode memberRegisterRequest = objectMapper.createObjectNode();
+    ObjectNode member = memberRegisterRequest.putObject("member");
     member.put("email", "seunghan@gamil.com")
         .put("password", "pass12343")
         .put("name", "seunghan")
@@ -26,7 +25,7 @@ class MemberControllerTest extends BasicControllerTest {
 
     mockMvc.perform(post("/api/v1/members")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectNode.toString()))
+            .content(memberRegisterRequest.toString()))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.member.email").value("seunghan@gamil.com"))
         .andExpect(jsonPath("$.member.name").value("seunghan"))
@@ -42,16 +41,16 @@ class MemberControllerTest extends BasicControllerTest {
     String name = "seunghan";
     String role = "GUEST";
 
-    유저_등록(email,password,name,role);
+    멤버_등록(email,password,name,role);
 
-    ObjectNode objectNode = objectMapper.createObjectNode();
-    ObjectNode loginMember = objectNode.putObject("member");
+    ObjectNode loginRequest = objectMapper.createObjectNode();
+    ObjectNode loginMember = loginRequest.putObject("member");
     loginMember.put("email", email)
         .put("password", password);
 
     mockMvc.perform(post("/api/v1/login")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectNode.toString()))
+            .content(loginRequest.toString()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.member.email").value(email))
         .andExpect(jsonPath("$.member.name").value(name))

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
@@ -37,41 +37,26 @@ class MemberControllerTest extends BasicControllerTest {
 
   @Test
   void 로그인_API() throws Exception {
-    // 로그인
-    ObjectNode objectNode = objectMapper.createObjectNode();
-    ObjectNode member = objectNode.putObject("member");
-    member.put("email", "seunghan@gamil.com")
-        .put("password", "pass12343")
-        .put("name", "seunghan")
-        .put("birthDate", "1998-04-21")
-        .put("phoneNumber", "010-1234-5678")
-        .put("role", "GUEST");
-
-    mockMvc.perform(post("/api/v1/members")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectNode.toString()))
-        .andExpect(status().isCreated());
-
-    ObjectNode objectNode2 = objectMapper.createObjectNode();
-
     String email = "seunghan@gamil.com";
     String password = "pass12343";
     String name = "seunghan";
+    String role = "GUEST";
 
-    ObjectNode loginMember = objectNode2.putObject("member");
+    유저_등록(email,password,name,role);
+
+    ObjectNode objectNode = objectMapper.createObjectNode();
+    ObjectNode loginMember = objectNode.putObject("member");
     loginMember.put("email", email)
         .put("password", password);
 
     mockMvc.perform(post("/api/v1/login")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectNode2.toString()))
+            .content(objectNode.toString()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.member.email").value(email))
         .andExpect(jsonPath("$.member.name").value(name))
         .andExpect(jsonPath("$.member.role").value("GUEST"))
         .andExpect(jsonPath("$.member.token").exists());
-
   }
-
 
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
@@ -7,8 +7,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
 
 
+@Transactional
 class MemberControllerTest extends BasicControllerTest {
 
   @Test


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [AIR-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- JWT 설정 추가
- 로그인 API 구현
- 로그인 테스트 추가
- BasicControllerTest에 유저등록, 로그인 추상화

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
저희 서비스에서 서비스를 이용하려면 기본적으로 회원가입과 로그인이 필요합니다.
매번 테스트마다 회원가입과 로그인을 구현하는 것은 코드의 중복이 되기에 BasicControllerTest에 추상화하였습니다.
또한 GUEST와 HOST 각각 하나씩 BeforeEach로 등록해 놓았으며 필요 시 추가로 등록시면 될 것 같습니다.

또한 로그인 시 BasicControllerTest의 token필드에 jwt 토큰이 저장되게 하였으며
앞으로 테스트 시 
로그인("guest@naver.com", "geust1234!);
를 하시고 mockMvc( ~~.header("token", token))~~
이런식으로 토큰 헤더를 추가시키셔서 테스트를 하시면 될 것 같습니다.

