### PR TITLE
[AIR-108] RESTDOCS 기본설정

### DIFF
--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/support/BaseControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/support/BaseControllerTest.java
@@ -1,0 +1,22 @@
+package com.gurudev.aircnc.controller.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+public abstract class BaseControllerTest {
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected String createJson(Object dto) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(dto);
+    }
+}

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/support/RestDocsConfig.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/support/RestDocsConfig.java
@@ -1,0 +1,20 @@
+package com.gurudev.aircnc.controller.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    @Bean
+    public RestDocumentationResultHandler write() {
+        return MockMvcRestDocumentation.document(
+                "{class-name}/{method-name}",
+                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+}

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/support/RestDocsTestSupport.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/support/RestDocsTestSupport.java
@@ -1,0 +1,35 @@
+package com.gurudev.aircnc.controller.support;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@Disabled
+@Import(RestDocsConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsTestSupport extends BaseControllerTest {
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+                .alwaysDo(print())
+                .alwaysDo(restDocs)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true)) // 한글 깨짐 방지
+                .build();
+    }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
- test 의 controller.support 패키지에 RestDocs 사용 공통 기능 추상화

## 🗨️ 기타

- 컨트롤러 테스트 작성시 RestDocsTestSupport 클래스를 상속 받기를 추천드립니다.
- ![image](https://user-images.githubusercontent.com/67302707/175193477-63944a75-fc1f-48e7-b931-44b9dd8bba77.png)
- 빨간줄이 보이는데 IDE 에러 같습니다. `JacksonAutoConfiguration` 라는 클래스에서 잘 등록되고 있습니다.

- 기존 BasicControllerTest 는 사용범위가 현재 회원가입으로 한정되어있어 제거하지는 않았습니다.
- 컨트롤러 테스트 작성시 아래와 같은 코드 스타일을 제안드립니다.

기존
```java
mockMvc.perform(post("/api/v1/members")
            .contentType(MediaType.APPLICATION_JSON)
            .content(objectNode.toString()))
        .andExpect(status().isCreated())
        .andExpect(jsonPath("$.member.email").value("seunghan@gamil.com"))
        .andExpect(jsonPath("$.member.name").value("seunghan"))
        .andExpect(jsonPath("$.member.birthDate").value("1998-04-21"))
        .andExpect(jsonPath("$.member.phoneNumber").value("010-1234-5678"))
        .andExpect(jsonPath("$.member.role").value("GUEST"))
```

제안
```java
mockMvc.perform(post("/posts")
                        .contentType(APPLICATION_JSON)
                        .content(createJson(postRequest))). // 추상 클래스의 createJson 메서드 활용
                .andExpect(status().isOk())
                .andExpectAll(                              //응답 바디에 대한 검증에 andExpectAll활용
                        jsonPath("$.postId").exists(),
                        jsonPath("$.title", "제목").exists(),  //jsonPath(expression).value(expectedvalue) 대신 jsonPath(expression,args).exists
                        jsonPath("$.content", "제목").exists(),
                        jsonPath("$.writer", "득윤").exists(),
                        jsonPath("$.writtenDateTime").exists()
                )
```

