### PR TITLE
 [AIR-96] 여행 취소 로직 도메인, 서비스

### DIFF
--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/Trip.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/Trip.java
@@ -11,6 +11,7 @@ import static lombok.AccessLevel.PROTECTED;
 import com.gurudev.aircnc.domain.base.BaseIdEntity;
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.room.entity.Room;
+import com.gurudev.aircnc.exception.NotFoundException;
 import com.gurudev.aircnc.exception.TripCancelException;
 import com.gurudev.aircnc.exception.TripReservationException;
 import java.time.LocalDate;
@@ -103,11 +104,19 @@ public class Trip extends BaseIdEntity {
     this.status = status;
   }
 
-  public void cancel(){
+  public void cancel(Member guest){
+    if(!isTripOf(guest)){
+      throw new NotFoundException(Trip.class);
+    }
+
     if(status != RESERVED){
       throw new TripCancelException(status);
     }
 
     this.status = CANCELLED;
+  }
+
+  private boolean isTripOf(Member guest) {
+    return guest.equals(this.guest);
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/Trip.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/Trip.java
@@ -1,7 +1,8 @@
 package com.gurudev.aircnc.domain.trip.entity;
 
-import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
+import static com.gurudev.aircnc.domain.trip.entity.TripStatus.CANCELLED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.RESERVED;
+import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
 import static java.time.LocalDate.now;
 import static java.time.Period.between;
 import static javax.persistence.FetchType.LAZY;
@@ -10,6 +11,7 @@ import static lombok.AccessLevel.PROTECTED;
 import com.gurudev.aircnc.domain.base.BaseIdEntity;
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.room.entity.Room;
+import com.gurudev.aircnc.exception.TripCancelException;
 import com.gurudev.aircnc.exception.TripReservationException;
 import java.time.LocalDate;
 import javax.persistence.Entity;
@@ -99,5 +101,13 @@ public class Trip extends BaseIdEntity {
 
   public void changeStatus(TripStatus status) {
     this.status = status;
+  }
+
+  public void cancel(){
+    if(status != RESERVED){
+      throw new TripCancelException(status);
+    }
+
+    this.status = CANCELLED;
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/TripStatus.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/TripStatus.java
@@ -1,17 +1,24 @@
 package com.gurudev.aircnc.domain.trip.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 /* 여행 상태 */
+@Getter
+@RequiredArgsConstructor
 public enum TripStatus {
 
   /* 예약 */
-  RESERVED,
+  RESERVED("예약"),
 
   /* 여행 중 */
-  TRAVELLING,
+  TRAVELLING("여행 중"),
 
   /* 완료 */
-  DONE,
-
+  DONE("완료"),
   /* 취소 */
-  CANCELLED
+
+  CANCELLED("취소");
+
+  private final String status;
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/repository/TripRepository.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/repository/TripRepository.java
@@ -3,10 +3,17 @@ package com.gurudev.aircnc.domain.trip.repository;
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.trip.entity.Trip;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
 
   List<Trip> findByGuest(Member guest);
 
+  @Query("select t "
+      + "from Trip t "
+      + "join fetch t.guest "
+      + "where t.id = :id")
+  Optional<Trip> findByIdFetchGuest(Long id);
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/service/TripService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/service/TripService.java
@@ -11,4 +11,6 @@ public interface TripService {
       int totalPrice);
 
   List<Trip> getByGuest(Member guest);
+
+  Trip cancel(Member guest, Long tripId);
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/service/TripServiceImpl.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/service/TripServiceImpl.java
@@ -24,8 +24,7 @@ public class TripServiceImpl implements TripService {
   @Override
   public Trip reserve(Member guest, Long roomId, LocalDate checkIn, LocalDate checkOut,
       int headCount, int totalPrice) {
-    Room room = roomRepository.findById(roomId)
-        .orElseThrow(() -> new NotFoundException(Room.class));
+    Room room = findRoomById(roomId);
 
     //TODO: 예약 겹치는지 검증 로직 필요
 
@@ -37,4 +36,22 @@ public class TripServiceImpl implements TripService {
   public List<Trip> getByGuest(Member guest) {
     return tripRepository.findByGuest(guest);
   }
+
+  @Override
+  public Trip cancel(Member guest, Long tripId) {
+    Trip trip = findTripByIdFetchGuest(tripId);
+
+    trip.cancel(guest);
+
+    return trip;
+  }
+
+  private Room findRoomById(Long roomId) {
+    return roomRepository.findById(roomId).orElseThrow(() -> new NotFoundException(Room.class));
+  }
+
+  private Trip findTripByIdFetchGuest(Long id) {
+    return tripRepository.findByIdFetchGuest(id).orElseThrow(() -> new NotFoundException(Trip.class));
+  }
+
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/exception/TripCancelException.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/exception/TripCancelException.java
@@ -1,0 +1,11 @@
+package com.gurudev.aircnc.exception;
+
+import com.gurudev.aircnc.domain.trip.entity.TripStatus;
+
+public class TripCancelException extends
+    AircncRuntimeException {
+
+  public TripCancelException(TripStatus tripStatus) {
+    super("%s 상태의 여행은 취소 할 수 없습니다".formatted(tripStatus.getStatus()));
+  }
+}

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
@@ -9,7 +9,6 @@ import static com.gurudev.aircnc.domain.util.Fixture.createGuest;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoom;
 import static com.gurudev.aircnc.domain.util.Fixture.createTrip;
 import static com.gurudev.aircnc.util.AssertionUtil.assertThatAircncRuntimeException;
-import static com.gurudev.aircnc.util.AssertionUtil.assertThatTripReservationException;
 import static java.time.LocalDate.now;
 import static java.time.Period.between;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.exception.TripCancelException;
+import com.gurudev.aircnc.exception.TripReservationException;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,14 +89,14 @@ class TripTest {
 
   @Test
   void 계산된_가격과_요청된_가격이_같아야_한다() {
-    assertThatTripReservationException()
+    assertThatExceptionOfType(TripReservationException.class)
         .isThrownBy(
             () -> Trip.ofReserved(guest, room, checkIn, checkOut, totalPrice + 1, headCount));
   }
 
   @Test
   void 여행_인원_수는_숙소의_최대_인원을_초과_할_수_없다() {
-    assertThatTripReservationException()
+    assertThatExceptionOfType(TripReservationException.class)
         .isThrownBy(() -> Trip.ofReserved(guest, room, checkIn, checkOut, totalPrice,
             room.getCapacity() + 1));
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
@@ -2,19 +2,22 @@ package com.gurudev.aircnc.domain.trip.entity;
 
 import static com.gurudev.aircnc.domain.trip.entity.Trip.TRIP_HEADCOUNT_MIN_VALUE;
 import static com.gurudev.aircnc.domain.trip.entity.Trip.TRIP_TOTAL_PRICE_MIN_VALUE;
+import static com.gurudev.aircnc.domain.trip.entity.TripStatus.CANCELLED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.RESERVED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.TRAVELLING;
 import static com.gurudev.aircnc.domain.util.Fixture.createGuest;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoom;
+import static com.gurudev.aircnc.domain.util.Fixture.createTrip;
 import static com.gurudev.aircnc.util.AssertionUtil.assertThatAircncRuntimeException;
 import static com.gurudev.aircnc.util.AssertionUtil.assertThatTripReservationException;
 import static java.time.LocalDate.now;
 import static java.time.Period.between;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.room.entity.Room;
+import com.gurudev.aircnc.exception.TripCancelException;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,15 +25,20 @@ import org.junit.jupiter.api.Test;
 
 class TripTest {
 
-  private final Member guest = createGuest();
-  private final Room room = createRoom();
+  private Member guest;
+  private Room room;
+
   private LocalDate checkIn;
   private LocalDate checkOut;
+
   private int totalPrice;
   private int headCount;
 
   @BeforeEach
   void setUp() {
+    guest = createGuest();
+    room = createRoom();
+
     checkIn = now().plusDays(1);
     checkOut = now().plusDays(2);
 
@@ -60,8 +68,7 @@ class TripTest {
   void CheckIn이_CheckOut_이전_이여야_한다() {
     assertThatAircncRuntimeException()
         .isThrownBy(
-            () -> Trip.ofReserved(guest, room, checkIn, checkIn.minusDays(1), totalPrice,
-                headCount));
+            () -> Trip.ofReserved(guest, room, checkIn, checkIn.minusDays(1), totalPrice, headCount));
   }
 
   @Test
@@ -92,5 +99,23 @@ class TripTest {
     assertThatTripReservationException()
         .isThrownBy(() -> Trip.ofReserved(guest, room, checkIn, checkOut, totalPrice,
             room.getCapacity() + 1));
+  }
+
+  @Test
+  void 예약_상태의_여행_취소_성공() {
+    Trip trip = createTrip();
+
+    trip.cancel();
+
+    assertThat(trip.getStatus()).isEqualTo(CANCELLED);
+  }
+
+  @Test
+  void 취소_상태의_여행_취소_실패() {
+    Trip trip = createTrip();
+    trip.cancel(); // -> trip.status = CANCELLED
+
+    assertThatExceptionOfType(TripCancelException.class)
+        .isThrownBy(trip::cancel);
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.gurudev.aircnc.domain.trip.service;
 
+import static com.gurudev.aircnc.domain.trip.entity.TripStatus.CANCELLED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.RESERVED;
 import static com.gurudev.aircnc.domain.util.Fixture.createGuest;
 import static com.gurudev.aircnc.domain.util.Fixture.createHost;
@@ -28,17 +29,23 @@ class TripServiceImplTest {
 
   @Autowired
   private TripService tripService;
+
   @Autowired
   private MemberService memberService;
+
   @Autowired
   private RoomService roomService;
 
+  private Room room;
+
+  private Member guest;
+
   private LocalDate checkIn;
   private LocalDate checkOut;
-  private Member guest;
-  private Room room;
-  private int totalPrice;
+
   private int headCount;
+  private int totalPrice;
+
   private Trip trip1;
   private Trip trip2;
 
@@ -55,6 +62,7 @@ class TripServiceImplTest {
 
     checkIn = now().plusDays(1);
     checkOut = now().plusDays(2);
+
     headCount = room.getCapacity();
     totalPrice = between(checkIn, checkOut).getDays() * room.getPricePerDay();
 
@@ -79,4 +87,12 @@ class TripServiceImplTest {
 
     assertThat(findTrips).hasSize(2).containsExactly(trip1, trip2);
   }
+
+  @Test
+  void 예약_상태의_여행_취소_성공() {
+    Trip cancelledTrip = tripService.cancel(guest, trip1.getId());
+
+    assertThat(cancelledTrip.getStatus()).isEqualTo(CANCELLED);
+  }
+
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/util/Fixture.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/util/Fixture.java
@@ -8,6 +8,7 @@ import com.gurudev.aircnc.domain.member.entity.Role;
 import com.gurudev.aircnc.domain.room.entity.Address;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.room.entity.RoomPhoto;
+import com.gurudev.aircnc.domain.trip.entity.Trip;
 import java.time.LocalDate;
 
 public class Fixture {
@@ -45,5 +46,10 @@ public class Fixture {
 
   public static RoomPhoto createRoomPhoto() {
     return new RoomPhoto("photo.jpg");
+  }
+
+  public static Trip createTrip() {
+    return Trip.ofReserved(createGuest(), createRoom(), LocalDate.now(),
+        LocalDate.now().plusDays(1), 100000, 4);
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/util/AssertionUtil.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/util/AssertionUtil.java
@@ -13,10 +13,6 @@ public class AssertionUtil {
     return assertThatExceptionOfType(AircncRuntimeException.class);
   }
 
-  public static ThrowableTypeAssert<TripReservationException> assertThatTripReservationException() {
-    return assertThatExceptionOfType(TripReservationException.class);
-  }
-
   public static ThrowableTypeAssert<NotFoundException> assertThatNotFoundException() {
     return assertThatExceptionOfType(NotFoundException.class);
   }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 여행 취소 로직 도메인, 서비스
- 생각없이 도메인 계층을 완료됨으로 했는데 생각보다 도메인 계층에 넣을게 많았네요.. 여기에 묻었습니다.

## 🗨️ 기타

- 취소 로직시 `Member` 를 전달받아 자신의 여행이 아니라면 `NotFoundException` 을 터트렸습니다.
공격으로 간주하고 로깅을 남겨도 좋을것 같습니다.

- `남의_여행_취소_실패` 테스트에서  도메인 계층에서 아이디가 다른 사용자를 생성하기 위해 `ReflectionTestUtils` 를 활용 하였습니다.

- 추가로 묻어가는 변경사항으로 AssertionUtil 의 사용 범위를 범용적인 `AirCncRuntimeException` 과 `NotFoundException` 으로 한정하고 개별적인 Usecase 예외는 `assertThatExceptionOfType(TripReservationException.class)` 이런식으로 쓰는 것이 더 나은거 같아 변경하였는데 이것 때문인지 자동 머지가 안된다고 하네요. 의견 들어보고 해결하겠습니다.

![image](https://user-images.githubusercontent.com/67302707/175259621-98fc1a75-f5f8-4fe4-a9f3-14d5a5b55e5a.png)
