### PR TITLE
[AIR 52] 숙소 리스트 조회 API 추가

### DIFF
--- a/aircnc/src/main/java/com/gurudev/aircnc/controller/RoomController.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/controller/RoomController.java
@@ -9,6 +9,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import com.gurudev.aircnc.configuration.jwt.JwtAuthentication;
 import com.gurudev.aircnc.controller.dto.RoomDto.RoomRegisterRequest;
 import com.gurudev.aircnc.controller.dto.RoomDto.RoomRegisterResponse;
+import com.gurudev.aircnc.controller.dto.RoomDto.RoomResponses;
 import com.gurudev.aircnc.domain.room.dto.RoomPhotoDto;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.room.entity.RoomPhoto;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,6 +54,14 @@ public class RoomController {
     Room room = roomService.register(roomDto.toDto(), roomPhotoDtos, authentication.id);
 
     return new ResponseEntity<>(of(room, roomPhotos), CREATED);
+  }
+
+  @GetMapping
+  public ResponseEntity<RoomResponses> getRooms(){
+    List<Room> rooms = roomService.getAll();
+
+    return ResponseEntity.ok(RoomResponses.of(rooms));
+
   }
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/controller/dto/RoomDto.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/controller/dto/RoomDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.gurudev.aircnc.domain.room.entity.Address;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.room.entity.RoomPhoto;
+import com.gurudev.aircnc.exception.NotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -87,6 +88,51 @@ public class RoomDto {
             .capacity(room.getCapacity())
             .fileNames(roomPhotos.stream().map(RoomPhoto::getFileName).collect(Collectors.toList()))
             .build();
+      }
+    }
+  }
+
+  @Getter
+  @RequiredArgsConstructor(access = PRIVATE)
+  public static class RoomResponses {
+
+    @JsonProperty("rooms")
+    private final List<RoomInfo> roomInfos;
+
+    public static RoomResponses of(List<Room> room) {
+      List<RoomInfo> roomInfos = room.stream().map(r -> RoomInfo.of(r))
+          .collect(Collectors.toList());
+      return new RoomResponses(roomInfos);
+    }
+
+    @Getter
+    public static class RoomInfo {
+
+      private final long id;
+      private final String address;
+      private final int pricePerDay;
+      private String photoUrl;
+//      private final String wishListId;
+
+      @Builder(access = PRIVATE)
+      public RoomInfo(long id, String address, int pricePerDay, String photoUrl) {
+        this.id = id;
+        this.address = address;
+        this.pricePerDay = pricePerDay;
+        this.photoUrl = photoUrl;
+      }
+
+      public static RoomInfo of(Room room) {
+        String photoUrl = room.getRoomPhotos().stream().findFirst().map(RoomPhoto::getFileName)
+            .orElseThrow(() -> new NotFoundException(RoomPhoto.class));
+
+        return RoomInfo.builder()
+            .id(room.getId())
+            .address(Address.toString(room.getAddress()))
+            .pricePerDay(room.getPricePerDay())
+            .photoUrl(photoUrl)
+            .build();
+
       }
     }
   }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 숙소 리스트 조회 API 테스트
- 숙소 리스트 조회 DTO, controller 로직 추가

## 🗨️ 기타
테스트에서 숙소를 3개 등록하고 API를 호출했을 때 그 갯수만큼 등록되었는지, 즉 잘 등록되고 그 개수만큼 불러오는지? 도 테스트를 해 보고 싶었는데 response에서 room_count와 같은 것을 반환하지 않도록 설계해 놓아 어떻게 테스트해야 할지 모르겠네요! 좋은 의견 있으시면 피드백 주세요!