### PR TITLE
[AIR-57] 숙소 변경 서비스 구현

### DIFF
--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/room/repository/RoomRepository.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/room/repository/RoomRepository.java
@@ -1,8 +1,11 @@
 package com.gurudev.aircnc.domain.room.repository;
 
 import com.gurudev.aircnc.domain.room.entity.Room;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
+
+  Optional<Room> findByIdAndHostId(Long id, Long hostId);
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/room/service/RoomService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/room/service/RoomService.java
@@ -2,6 +2,7 @@ package com.gurudev.aircnc.domain.room.service;
 
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.room.service.command.RoomCommand.RoomRegisterCommand;
+import com.gurudev.aircnc.domain.room.service.command.RoomCommand.RoomUpdateCommand;
 import java.util.List;
 
 public interface RoomService {
@@ -9,4 +10,6 @@ public interface RoomService {
   Room register(RoomRegisterCommand roomRegisterCommand);
 
   List<Room> getAll();
+
+  Room update(RoomUpdateCommand roomUpdateCommand);
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/room/service/RoomServiceImpl.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/room/service/RoomServiceImpl.java
@@ -5,6 +5,7 @@ import com.gurudev.aircnc.domain.member.repository.MemberRepository;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.room.repository.RoomRepository;
 import com.gurudev.aircnc.domain.room.service.command.RoomCommand.RoomRegisterCommand;
+import com.gurudev.aircnc.domain.room.service.command.RoomCommand.RoomUpdateCommand;
 import com.gurudev.aircnc.exception.NotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -35,5 +36,16 @@ public class RoomServiceImpl implements RoomService {
   @Override
   public List<Room> getAll() {
     return roomRepository.findAll();
+  }
+
+  @Transactional
+  @Override
+  public Room update(RoomUpdateCommand roomUpdateCommand) {
+    Room room = roomRepository
+        .findByIdAndHostId(roomUpdateCommand.getRoomId(), roomUpdateCommand.getHostId())
+        .orElseThrow(() -> new NotFoundException(Room.class));
+
+    return room.update(roomUpdateCommand.getName(), roomUpdateCommand.getDescription(),
+        roomUpdateCommand.getPricePerDay());
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/room/service/command/RoomCommand.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/room/service/command/RoomCommand.java
@@ -9,6 +9,7 @@ import com.gurudev.aircnc.domain.room.entity.RoomPhoto;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -82,6 +83,29 @@ public final class RoomCommand {
           registerRequest.getPricePerDay(),
           registerRequest.getCapacity(),
           roomPhotoFiles, hostId);
+    }
+  }
+
+  @Getter
+  public static class RoomUpdateCommand {
+
+    private final Long hostId;
+
+    private final Long roomId;
+
+    private final String name;
+
+    private final String description;
+
+    private final Integer pricePerDay;
+
+    public RoomUpdateCommand(Long hostId, Long roomId, String name, String description,
+        Integer pricePerDay) {
+      this.hostId = hostId;
+      this.roomId = roomId;
+      this.name = name;
+      this.description = description;
+      this.pricePerDay = pricePerDay;
     }
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
@@ -3,17 +3,21 @@ package com.gurudev.aircnc.domain.room.service;
 import static com.gurudev.aircnc.domain.util.Command.ofRoom;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoom;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoomPhoto;
+import static com.gurudev.aircnc.util.AssertionUtil.assertThatNotFoundException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.member.service.MemberService;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.room.entity.RoomPhoto;
+import com.gurudev.aircnc.domain.room.service.command.RoomCommand.RoomUpdateCommand;
 import com.gurudev.aircnc.domain.util.Command;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,8 +48,7 @@ class RoomServiceImplTest {
     roomPhotos = List.of(createRoomPhoto(), createRoomPhoto());
 
     room1 = roomService.register(ofRoom(room1, roomPhotos, host.getId()));
-    room2 = roomService.register(
-        ofRoom(room2, Collections.emptyList(), host.getId()));
+    room2 = roomService.register(ofRoom(room2, Collections.emptyList(), host.getId()));
   }
 
   @Test
@@ -66,5 +69,47 @@ class RoomServiceImplTest {
 
     assertThat(rooms).hasSize(2)
         .containsExactly(room1, room2);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "변경된 숙소 이름, 변경된 숙소 설명입니다, 25000",
+      "변경된 숙소 이름, , ",
+      " , 변경된 숙소 설명입니다, ",
+      " , , 25000"
+  })
+  void 숙소_이름_설명_가격_변경_성공(String updatedName, String updatedDescription,
+      Integer updatedPricePerDay) {
+    //given
+    String originalName = room1.getName();
+    String originalDescription = room1.getDescription();
+    Integer originalPricePerDay = room1.getPricePerDay();
+    RoomUpdateCommand roomUpdateCommand = new RoomUpdateCommand(room1.getHost().getId(),
+        room1.getId(), updatedName, updatedDescription, updatedPricePerDay);
+
+    //when
+    Room updatedRoom = roomService.update(roomUpdateCommand);
+
+    //then
+    assertThat(updatedRoom)
+        .extracting(
+            Room::getName,
+            Room::getDescription,
+            Room::getPricePerDay
+        ).isEqualTo(
+            List.of(updatedName == null ? originalName : updatedName,
+                updatedDescription == null ? originalDescription : updatedDescription,
+                updatedPricePerDay == null ? originalPricePerDay : updatedPricePerDay));
+  }
+
+  @Test
+  void 해당_숙소의_호스트가_아닌_경우_변경_실패() {
+    //given
+    RoomUpdateCommand roomUpdateCommand = new RoomUpdateCommand(host.getId() + 1,
+        room1.getId(), "변경할 숙소 이름", "변경할 숙소 설명입니다", 25000);
+
+    //then
+    assertThatNotFoundException()
+        .isThrownBy(() -> roomService.update(roomUpdateCommand));
   }
 }


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [AIR-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 숙소 변경 서비스 구현
- Command의 hostId랑 해당 room의 hostId랑 다르면 NotFoundException 던지도록 작성했습니다.
