### PR TITLE
[AIR-127] 테스트 코드 리팩토링

### DIFF
--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/member/service/command/MemberCommand.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/member/service/command/MemberCommand.java
@@ -38,7 +38,6 @@ public final class MemberCommand {
           new PhoneNumber(this.phoneNumber),
           Role.valueOf(this.role));
     }
-
   }
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/security/PasswordEncryptor.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/security/PasswordEncryptor.java
@@ -17,5 +17,4 @@ public class PasswordEncryptor {
     return passwordEncoder.matches(rawPassword, encodedPassword);
   }
 
-
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
@@ -13,11 +13,6 @@ import org.springframework.http.MediaType;
 
 class MemberControllerTest extends RestDocsTestSupport {
 
-  private final String email = "seunghan@gamil.com";
-  private final String password = "pass12343";
-  private final String name = "seunghan";
-  private final String role = "GUEST";
-
   @Test
   void 회원가입_API() throws Exception {
     ObjectNode memberRegisterRequest = objectMapper.createObjectNode();
@@ -44,21 +39,20 @@ class MemberControllerTest extends RestDocsTestSupport {
 
   @Test
   void 로그인_API() throws Exception {
-
-    멤버_등록(email, password, name, role);
+    멤버_등록("seunghan@gamil.com", "pass12343", "seunghan", "GUEST");
 
     ObjectNode loginRequest = objectMapper.createObjectNode();
     ObjectNode loginMember = loginRequest.putObject("member");
-    loginMember.put("email", email)
-        .put("password", password);
+    loginMember.put("email", "seunghan@gamil.com")
+        .put("password", "pass12343");
 
     mockMvc.perform(post("/api/v1/login")
             .contentType(MediaType.APPLICATION_JSON)
             .content(loginRequest.toString()))
         .andExpect(status().isOk())
         .andExpectAll(
-            jsonPath("$.member.email").value(email),
-            jsonPath("$.member.name").value(name),
+            jsonPath("$.member.email").value("seunghan@gamil.com"),
+            jsonPath("$.member.name").value("seunghan"),
             jsonPath("$.member.role").value("GUEST"),
             jsonPath("$.member.token").exists()
         );
@@ -66,19 +60,18 @@ class MemberControllerTest extends RestDocsTestSupport {
 
   @Test
   void 정보조회_API() throws Exception {
-
-    멤버_등록(email, password, name, role);
-    로그인(email, password);
+    멤버_등록("seunghan@gamil.com", "pass12343", "seunghan", "GUEST");
+    로그인("seunghan@gamil.com", "pass12343");
 
     mockMvc.perform(get("/api/v1/me")
             .header(AUTHORIZATION, token))
         .andExpect(status().isOk())
         .andExpectAll(
-            jsonPath("$.member.email").value(email),
-            jsonPath("$.member.name").value(name),
+            jsonPath("$.member.email").value("seunghan@gamil.com"),
+            jsonPath("$.member.name").value("seunghan"),
             jsonPath("$.member.birthDate").value("1998-04-21"),
             jsonPath("$.member.phoneNumber").value("010-1234-5678"),
-            jsonPath("$.member.role").value(role)
+            jsonPath("$.member.role").value("GUEST")
         );
   }
 

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
@@ -33,11 +33,13 @@ class MemberControllerTest extends RestDocsTestSupport {
             .contentType(MediaType.APPLICATION_JSON)
             .content(memberRegisterRequest.toString()))
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.member.email").value("seunghan@gamil.com"))
-        .andExpect(jsonPath("$.member.name").value("seunghan"))
-        .andExpect(jsonPath("$.member.birthDate").value("1998-04-21"))
-        .andExpect(jsonPath("$.member.phoneNumber").value("010-1234-5678"))
-        .andExpect(jsonPath("$.member.role").value("GUEST"));
+        .andExpectAll(
+            jsonPath("$.member.email").value("seunghan@gamil.com"),
+            jsonPath("$.member.name").value("seunghan"),
+            jsonPath("$.member.birthDate").value("1998-04-21"),
+            jsonPath("$.member.phoneNumber").value("010-1234-5678"),
+            jsonPath("$.member.role").value("GUEST")
+        );
   }
 
   @Test
@@ -54,10 +56,12 @@ class MemberControllerTest extends RestDocsTestSupport {
             .contentType(MediaType.APPLICATION_JSON)
             .content(loginRequest.toString()))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.member.email").value(email))
-        .andExpect(jsonPath("$.member.name").value(name))
-        .andExpect(jsonPath("$.member.role").value("GUEST"))
-        .andExpect(jsonPath("$.member.token").exists());
+        .andExpectAll(
+            jsonPath("$.member.email").value(email),
+            jsonPath("$.member.name").value(name),
+            jsonPath("$.member.role").value("GUEST"),
+            jsonPath("$.member.token").exists()
+        );
   }
 
   @Test
@@ -69,11 +73,13 @@ class MemberControllerTest extends RestDocsTestSupport {
     mockMvc.perform(get("/api/v1/me")
             .header(AUTHORIZATION, token))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.member.email").value(email))
-        .andExpect(jsonPath("$.member.name").value(name))
-        .andExpect(jsonPath("$.member.birthDate").value("1998-04-21"))
-        .andExpect(jsonPath("$.member.phoneNumber").value("010-1234-5678"))
-        .andExpect(jsonPath("$.member.role").value(role));
+        .andExpectAll(
+            jsonPath("$.member.email").value(email),
+            jsonPath("$.member.name").value(name),
+            jsonPath("$.member.birthDate").value("1998-04-21"),
+            jsonPath("$.member.phoneNumber").value("010-1234-5678"),
+            jsonPath("$.member.role").value(role)
+        );
   }
 
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
@@ -15,6 +15,7 @@ class MemberControllerTest extends RestDocsTestSupport {
 
   @Test
   void 회원가입_API() throws Exception {
+    //given
     ObjectNode memberRegisterRequest = objectMapper.createObjectNode();
     ObjectNode member = memberRegisterRequest.putObject("member");
     member.put("email", "seunghan@gamil.com")
@@ -24,9 +25,12 @@ class MemberControllerTest extends RestDocsTestSupport {
         .put("phoneNumber", "010-1234-5678")
         .put("role", "GUEST");
 
+    //when
     mockMvc.perform(post("/api/v1/members")
             .contentType(MediaType.APPLICATION_JSON)
             .content(memberRegisterRequest.toString()))
+
+        //then
         .andExpect(status().isCreated())
         .andExpectAll(
             jsonPath("$.member.email").value("seunghan@gamil.com"),
@@ -39,6 +43,7 @@ class MemberControllerTest extends RestDocsTestSupport {
 
   @Test
   void 로그인_API() throws Exception {
+    //given
     멤버_등록("seunghan@gamil.com", "pass12343", "seunghan", "GUEST");
 
     ObjectNode loginRequest = objectMapper.createObjectNode();
@@ -46,9 +51,12 @@ class MemberControllerTest extends RestDocsTestSupport {
     loginMember.put("email", "seunghan@gamil.com")
         .put("password", "pass12343");
 
+    //when
     mockMvc.perform(post("/api/v1/login")
             .contentType(MediaType.APPLICATION_JSON)
             .content(loginRequest.toString()))
+
+        //then
         .andExpect(status().isOk())
         .andExpectAll(
             jsonPath("$.member.email").value("seunghan@gamil.com"),
@@ -60,11 +68,15 @@ class MemberControllerTest extends RestDocsTestSupport {
 
   @Test
   void 정보조회_API() throws Exception {
+    //given
     멤버_등록("seunghan@gamil.com", "pass12343", "seunghan", "GUEST");
     로그인("seunghan@gamil.com", "pass12343");
 
+    //when
     mockMvc.perform(get("/api/v1/me")
             .header(AUTHORIZATION, token))
+
+        //then
         .andExpect(status().isOk())
         .andExpectAll(
             jsonPath("$.member.email").value("seunghan@gamil.com"),

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/MemberControllerTest.java
@@ -74,5 +74,4 @@ class MemberControllerTest extends RestDocsTestSupport {
             jsonPath("$.member.role").value("GUEST")
         );
   }
-
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/RoomControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/RoomControllerTest.java
@@ -28,6 +28,7 @@ class RoomControllerTest extends RestDocsTestSupport {
 
   @Test
   void 숙소_등록() throws Exception {
+    //given
     InputStream requestInputStream = new FileInputStream(
         "src/test/resources/room-photos-src/photo1.jpeg");
     MockMultipartFile requestImage = new MockMultipartFile("roomPhotosFile", "photo1.jpeg",
@@ -35,6 +36,7 @@ class RoomControllerTest extends RestDocsTestSupport {
 
     로그인("host@naver.com", "host1234!");
 
+    //when
     mockMvc.perform(multipart("/api/v1/rooms")
             .file(requestImage)
             .param("name", "나의 숙소")
@@ -46,6 +48,8 @@ class RoomControllerTest extends RestDocsTestSupport {
             .param("pricePerDay", "100000")
             .param("capacity", "2")
             .header(AUTHORIZATION, token))
+
+        //then
         .andExpect(status().isCreated())
         .andExpectAll(
             jsonPath("$.room.id").exists(),
@@ -56,6 +60,8 @@ class RoomControllerTest extends RestDocsTestSupport {
             jsonPath("$.room.capacity").value("2"),
             jsonPath("$.room.fileNames", hasSize(1))
         )
+
+        //docs
         .andDo(
             restDocs.document(
                 requestHeaders(

--- a/aircnc/src/test/java/com/gurudev/aircnc/controller/support/BaseControllerTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/controller/support/BaseControllerTest.java
@@ -17,9 +17,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
 @Transactional
 @AutoConfigureMockMvc
+@SpringBootTest
 public class BaseControllerTest {
 
   @Autowired

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/EmailTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/EmailTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 class EmailTest {
 
-
   @Test
   void 이메일_생성_성공() {
     Email email = new Email("test@email.com");

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/EmailTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/EmailTest.java
@@ -12,14 +12,20 @@ class EmailTest {
 
   @Test
   void 이메일_생성_성공() {
-    Email email = new Email("test@email.com");
+    //given
+    String emailString = "test@email.com";
 
-    assertThat(email).isEqualTo(new Email("test@email.com"));
+    //when
+    Email email = new Email(emailString);
+
+    //then
+    assertThat(email).isEqualTo(new Email(emailString));
   }
 
   @ParameterizedTest
   @CsvSource(value = {"test.email.com", "@email.com"})
   void 이메일_생성_실패(String invalidEmail) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Email(invalidEmail));
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/MemberTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/MemberTest.java
@@ -5,22 +5,35 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 import java.time.LocalDate;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class MemberTest {
 
-  private final Email email = new Email("ndy@haha.com");
-  private final Password password = new Password("paSSword!");
-  private final String name = "ndy";
-  private final LocalDate birthDate = LocalDate.of(1997, 8, 21);
-  private final PhoneNumber phoneNumber = new PhoneNumber("010-1234-5678");
+  private Email email;
+  private Password password;
+  private String name;
+  private LocalDate birthDate;
+  private PhoneNumber phoneNumber;
+
+  @BeforeEach
+  void setUp() {
+    //given
+    email = new Email("ndy@haha.com");
+    password = new Password("paSSword!");
+    name = "ndy";
+    birthDate = LocalDate.of(1997, 8, 21);
+    phoneNumber = new PhoneNumber("010-1234-5678");
+  }
 
   @Test
   void 회원_생성() {
+    //when
     Member member = new Member(email, password, name, birthDate, phoneNumber, Role.GUEST);
 
+    //tehn
     assertThat(member).extracting(Member::getEmail, Member::getPassword, Member::getName,
             Member::getBirthDate, Member::getPhoneNumber)
         .isEqualTo(List.of(email, password, name, birthDate, phoneNumber));
@@ -29,12 +42,14 @@ class MemberTest {
   @ParameterizedTest
   @NullAndEmptySource
   void 이름_공백_불가(String name) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Member(email, password, name, birthDate, phoneNumber, Role.GUEST));
   }
 
   @Test
   void 생일_null_불가() {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Member(email, password, name, null, phoneNumber, Role.GUEST));
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/MemberTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/MemberTest.java
@@ -34,7 +34,7 @@ class MemberTest {
   }
 
   @Test
-  void 생일_공백_불가() {
+  void 생일_null_불가() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Member(email, password, name, null, phoneNumber, Role.GUEST));
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/PasswordTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/PasswordTest.java
@@ -28,14 +28,13 @@ class PasswordTest {
         .isThrownBy(() -> new Password(invalidPassword));
   }
 
-  @ParameterizedTest
-  @CsvSource(value = {"12345678", "123456789012345"})
-  void 비밀번호_암호화_성공_테스트(String rawPassword) {
-    Password password = new Password(rawPassword);
+  @Test
+  void 비밀번호_암호화_성공_테스트() {
+    Password password = new Password("password");
 
     password.encode(passwordEncryptor);
 
-    assertThat(password.matches(passwordEncryptor, new Password(rawPassword))).isTrue();
+    assertThat(password.matches(passwordEncryptor, new Password("password"))).isTrue();
   }
 
   @ParameterizedTest
@@ -52,8 +51,7 @@ class PasswordTest {
   void 암호화_되지_않은_비밀번호는_일치여부_확인불가() {
     Password password = new Password("abcdefggg");
 
-    assertThatIllegalStateException().isThrownBy(
-        () -> password.matches(passwordEncryptor, new Password("abcdefggg"))
-    );
+    assertThatIllegalStateException()
+        .isThrownBy(() -> password.matches(passwordEncryptor, new Password("abcdefggg")));
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/PasswordTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/PasswordTest.java
@@ -16,42 +16,55 @@ class PasswordTest {
   @ParameterizedTest
   @CsvSource(value = {"12345678", "123456789012345"})
   void 비밀번호_생성_성공(String rawPassword) {
+    //when
     Password password = new Password(rawPassword);
 
+    //then
     assertThat(password).isEqualTo(new Password(rawPassword));
   }
 
   @ParameterizedTest
   @CsvSource(value = {"1234567", "1234567890123456"})
   void 비밀번호는_8자이상_15자이하(String invalidPassword) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Password(invalidPassword));
   }
 
   @Test
   void 비밀번호_암호화_성공_테스트() {
+    //given
     Password password = new Password("password");
-
     password.encode(passwordEncryptor);
 
-    assertThat(password.matches(passwordEncryptor, new Password("password"))).isTrue();
+    //when
+    boolean matchResult = password.matches(passwordEncryptor, new Password("password"));
+
+    //then
+    assertThat(matchResult).isTrue();
   }
 
   @ParameterizedTest
   @CsvSource(value = {"12345678", "123456789012345"})
   void 암호화된_비밀번호_불일치_테스트(String rawPassword) {
+    //given
     Password password = new Password(rawPassword);
-
     password.encode(passwordEncryptor);
 
-    assertThat(password.matches(passwordEncryptor, new Password("invalidPassword"))).isFalse();
+    //when
+    boolean matchResult = password.matches(passwordEncryptor, new Password("invalidPassword"));
+
+    //then
+    assertThat(matchResult).isFalse();
   }
 
   @Test
   void 암호화_되지_않은_비밀번호는_일치여부_확인불가() {
-    Password password = new Password("abcdefggg");
+    //given
+    Password password = new Password("nonEncrypted");
 
+    //then
     assertThatIllegalStateException()
-        .isThrownBy(() -> password.matches(passwordEncryptor, new Password("abcdefggg")));
+        .isThrownBy(() -> password.matches(passwordEncryptor, new Password("nonEncrypted")));
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/PhoneNumberTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/PhoneNumberTest.java
@@ -12,14 +12,17 @@ class PhoneNumberTest {
   @ParameterizedTest
   @CsvSource(value = {"010-123-4567", "010-1234-5678"})
   void 전화번호_생성_성공(String testPhoneNumber) {
+    //when
     PhoneNumber phoneNumber = new PhoneNumber(testPhoneNumber);
 
+    //then
     assertThat(phoneNumber).isEqualTo(new PhoneNumber(testPhoneNumber));
   }
 
   @ParameterizedTest
   @CsvSource(value = {"0101234567", "010-12345678", "0-1234-5678", "070-123-4567"})
   void 전화번호_생성_실패(String testPhoneNumber) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new PhoneNumber(testPhoneNumber));
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/MemberServiceTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/MemberServiceTest.java
@@ -4,6 +4,7 @@ import static com.gurudev.aircnc.domain.util.Fixture.createGuest;
 import static com.gurudev.aircnc.util.AssertionUtil.assertThatNotFoundException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 import com.gurudev.aircnc.domain.member.entity.Email;
 import com.gurudev.aircnc.domain.member.entity.Member;
@@ -20,8 +21,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
 @Transactional
+@SpringBootTest(webEnvironment = NONE)
 class MemberServiceTest {
 
   @Autowired

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/MemberServiceTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/MemberServiceTest.java
@@ -30,10 +30,10 @@ class MemberServiceTest {
   @Autowired
   private PasswordEncryptor passwordEncryptor;
 
-  private Member member = createGuest();
 
   @Test
   void 회원_가입_성공_테스트() {
+    Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
     member = memberService.register(command);
 
@@ -50,16 +50,18 @@ class MemberServiceTest {
 
   @Test
   void 회원_조회_성공_테스트() {
+    Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
-    Member member = memberService.register(command);
+    member = memberService.register(command);
 
     Member foundMember = memberService.getByEmail(member.getEmail());
 
-    assertThat(foundMember).isEqualTo(foundMember);
+    assertThat(foundMember).isEqualTo(member);
   }
 
   @Test
   void 존재하지_않는_회원에_대한_조회_실패() {
+    Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
     Email email = new Email(command.getEmail());
 
@@ -69,6 +71,7 @@ class MemberServiceTest {
 
   @Test
   void 로그인_성공_테스트() {
+    Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
     memberService.register(command);
 
@@ -81,6 +84,7 @@ class MemberServiceTest {
 
   @Test
   void 로그인_실패_테스트() {
+    Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
     memberService.register(command);
 

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/MemberServiceTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/MemberServiceTest.java
@@ -27,9 +27,10 @@ class MemberServiceTest {
   @Autowired
   private MemberService memberService;
 
-  private Member member = createGuest();
+  @Autowired
+  private PasswordEncryptor passwordEncryptor;
 
-  private final PasswordEncryptor passwordEncryptor = new PasswordEncryptor();
+  private Member member = createGuest();
 
   @Test
   void 회원_가입_성공_테스트() {

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/MemberServiceTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/MemberServiceTest.java
@@ -33,10 +33,14 @@ class MemberServiceTest {
 
   @Test
   void 회원_가입_성공_테스트() {
+    //given
     Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
+
+    //when
     member = memberService.register(command);
 
+    //then
     //생성된 회원의 필드가 회원 가입 명령의 필드와 일치하는지 검증
     assertThat(member).extracting(Member::getEmail, Member::getName, Member::getBirthDate,
             Member::getPhoneNumber, Member::getRole)
@@ -50,44 +54,54 @@ class MemberServiceTest {
 
   @Test
   void 회원_조회_성공_테스트() {
+    //given
     Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
     member = memberService.register(command);
 
+    //when
     Member foundMember = memberService.getByEmail(member.getEmail());
 
+    //then
     assertThat(foundMember).isEqualTo(member);
   }
 
   @Test
   void 존재하지_않는_회원에_대한_조회_실패() {
+    //given
     Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
     Email email = new Email(command.getEmail());
 
+    //then
     assertThatNotFoundException()
         .isThrownBy(() -> memberService.getByEmail(email));
   }
 
   @Test
   void 로그인_성공_테스트() {
+    //given
     Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
     memberService.register(command);
 
+    //when
     String rawPassword = command.getPassword();
     Email email = new Email(command.getEmail());
     Member loginMember = memberService.login(email, new Password(rawPassword));
 
+    //then
     assertThat(loginMember.getEmail()).isEqualTo(email);
   }
 
   @Test
   void 로그인_실패_테스트() {
+    //given
     Member member = createGuest();
     MemberRegisterCommand command = Command.ofRegisterMember(member);
     memberService.register(command);
 
+    //then
     Email email = new Email(command.getEmail());
     Password invalidPassword = new Password("invalidPassword");
     assertThatExceptionOfType(BadCredentialsException.class)

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/AddressTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/AddressTest.java
@@ -3,27 +3,40 @@ package com.gurudev.aircnc.domain.room.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class AddressTest {
 
-  private final String lotAddress = "전라북도 전주시 완산구 풍산동 123-1";
-  private final String roadAddress = "전라북도 전주시 완산구 풍산1로 1길";
-  private final String detailedAddress = "123호";
-  private final String postCode = "12345";
+
+  private String lotAddress;
+  private String roadAddress;
+  private String detailedAddress;
+  private String postCode;
+
+  @BeforeEach
+  void setUp() {
+    lotAddress = "전라북도 전주시 완산구 풍산동 123-1";
+    roadAddress = "전라북도 전주시 완산구 풍산1로 1길";
+    detailedAddress = "123호";
+    postCode = "12345";
+  }
 
   @Test
   void 주소_생성() {
+    //when
     Address address = new Address(lotAddress, roadAddress, detailedAddress, postCode);
 
+    //then
     assertThat(address).isEqualTo(new Address(lotAddress, roadAddress, detailedAddress, postCode));
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   void 지번_주소가_공백인_주소_생성_실패(String lotAddress) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Address(lotAddress, roadAddress, detailedAddress, postCode));
   }
@@ -31,6 +44,7 @@ class AddressTest {
   @ParameterizedTest
   @NullAndEmptySource
   void 도로명_주소가_공백인_주소_생성_실패(String roadAddress) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Address(lotAddress, roadAddress, detailedAddress, postCode));
   }
@@ -38,6 +52,7 @@ class AddressTest {
   @ParameterizedTest
   @NullAndEmptySource
   void 상세_주소가_공백인_주소_생성_실패(String detailedAddress) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Address(lotAddress, roadAddress, detailedAddress, postCode));
   }
@@ -45,6 +60,7 @@ class AddressTest {
   @ParameterizedTest
   @NullAndEmptySource
   void 우편번호가_공백인_주소_생성_실패(String postCode) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Address(lotAddress, roadAddress, detailedAddress, postCode));
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/AddressTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/AddressTest.java
@@ -37,7 +37,7 @@ class AddressTest {
 
   @ParameterizedTest
   @NullAndEmptySource
-  void 상세_주소가_공백인_주소_생성_실패(String roadAddress) {
+  void 상세_주소가_공백인_주소_생성_실패(String detailedAddress) {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Address(lotAddress, roadAddress, detailedAddress, postCode));
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/RoomPhotoTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/RoomPhotoTest.java
@@ -11,14 +11,20 @@ class RoomPhotoTest {
 
   @Test
   void 숙소_사진_생성() {
-    RoomPhoto roomPhoto = new RoomPhoto("photo.jpg");
+    //given
+    String fileName = "photo.jpg";
 
-    assertThat(roomPhoto.getFileName()).isEqualTo("photo.jpg");
+    //when
+    RoomPhoto roomPhoto = new RoomPhoto(fileName);
+
+    //then
+    assertThat(roomPhoto.getFileName()).isEqualTo(fileName);
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   void 파일_이름이_공백인_숙소_사진_생성_실패(String invalidFileName) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new RoomPhoto(invalidFileName));
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/RoomTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/RoomTest.java
@@ -64,7 +64,7 @@ class RoomTest {
   }
 
   @Test
-  void 인원수가_0이하인_작은_숙소_생성_실패() {
+  void 인원수가_0이하인_숙소_생성_실패() {
     int invalidCapacity = 0;
 
     assertThatIllegalArgumentException()

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/RoomTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/entity/RoomTest.java
@@ -11,31 +11,44 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import com.gurudev.aircnc.domain.member.entity.Member;
 import java.util.List;
 import net.bytebuddy.utility.RandomString;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class RoomTest {
 
-  private final String name = "전주 한옥마을";
-  private final Address address = createAddress();
-  private final String description = "아주 멋진 한옥마을입니다.";
-  private final int capacity = 4;
-  private final int pricePerDay = 100000;
+  private String name;
+  private Address address;
+  private String description;
+  private int capacity;
+  private int pricePerDay;
+
+  @BeforeEach
+  void setUp() {
+    name = "전주 한옥마을";
+    address = createAddress();
+    description = "아주 멋진 한옥마을입니다.";
+    capacity = 4;
+    pricePerDay = 100000;
+  }
 
   @Test
   void 숙소_생성() {
+    //when
     Room room = new Room(name, address, description, pricePerDay, capacity);
 
+    //then
     assertThat(room)
         .extracting(Room::getName, Room::getAddress, Room::getDescription, Room::getPricePerDay,
-                Room::getCapacity)
+            Room::getCapacity)
         .isEqualTo(List.of(name, address, description, pricePerDay, capacity));
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   void 이름이_공백인_숙소_생성_실패(String invalidName) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Room(invalidName, address, description, pricePerDay, capacity));
   }
@@ -43,40 +56,50 @@ class RoomTest {
   @ParameterizedTest
   @NullAndEmptySource
   void 설명이_공백인_숙소_생성_실패(String invalidDescription) {
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Room(name, address, invalidDescription, pricePerDay, capacity));
   }
 
   @Test
   void 설명의_길이_제한에_맞지않는_숙소_생성_실패() {
+    //given
     String invalidDescription = RandomString.make(ROOM_DESCRIPTION_MIN_LENGTH - 1);
 
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Room(name, address, invalidDescription, pricePerDay, capacity));
   }
 
   @Test
   void 가격이_제한에_맞지않는_숙소_생성_실패() {
+    //given
     int invalidPricePerDay = ROOM_PRICE_PER_DAY_MIN_VALUE - 1;
 
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Room(name, address, description, invalidPricePerDay, capacity));
   }
 
   @Test
   void 인원수가_0이하인_숙소_생성_실패() {
+    //given
     int invalidCapacity = 0;
 
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Room(name, address, description, pricePerDay, invalidCapacity));
   }
 
   @Test
   void 숙소의_이름_설명_가격을_변경할_수_있다() {
+    //given
     Room room = createRoom();
 
+    //when
     room.update("변경된 숙소 이름", "변경된 숙소 설명입니다", 20000);
 
+    //then
     assertThat(room)
         .extracting(Room::getName, Room::getDescription, Room::getPricePerDay)
         .isEqualTo(List.of("변경된 숙소 이름", "변경된 숙소 설명입니다", 20000));
@@ -84,11 +107,14 @@ class RoomTest {
 
   @Test
   void 숙소의_호스트_할당() {
+    //given
     Room room = createRoom();
     Member host = createHost();
 
+    //when
     room.assignHost(host);
 
+    //then
     assertThat(room.getHost()).isEqualTo(host);
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/LocalRoomPhotoServiceTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/LocalRoomPhotoServiceTest.java
@@ -9,7 +9,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,23 +28,23 @@ class LocalRoomPhotoServiceTest {
 
   MockMultipartFile requestImage;
 
-  @BeforeEach
-  void setUp() throws IOException {
-    InputStream requestInputStream = new FileInputStream(
-        "src/test/resources/room-photos-src/photo1.jpeg");
-
-    requestImage = new MockMultipartFile("photo1", "photo1.jpeg", IMAGE_JPEG_VALUE,
-        requestInputStream);
-  }
-
   @Test
   void 로컬_숙소_사진_등록_성공() throws IOException {
+    //given
+    InputStream requestInputStream =
+        new FileInputStream("src/test/resources/room-photos-src/photo1.jpeg");
+
+    requestImage =
+        new MockMultipartFile("photo1", "photo1.jpeg", IMAGE_JPEG_VALUE, requestInputStream);
+
+    //when
     List<RoomPhoto> uploadedRoomPhoto = roomPhotoService.upload(List.of(requestImage));
+
+    //then
     String fileName = uploadedRoomPhoto.get(0).getFileName();
-
     InputStream uploadedInputStream = new FileInputStream(roomPhotosPath + fileName);
-    InputStream requestInputStream = requestImage.getInputStream();
 
+    requestInputStream = requestImage.getInputStream();
     assertThat(contentEquals(uploadedInputStream, requestInputStream)).isTrue();
   }
 

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/LocalRoomPhotoServiceTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/LocalRoomPhotoServiceTest.java
@@ -26,15 +26,13 @@ class LocalRoomPhotoServiceTest {
   @Value("${room-photos.path}")
   private String roomPhotosPath;
 
-  MockMultipartFile requestImage;
-
   @Test
   void 로컬_숙소_사진_등록_성공() throws IOException {
     //given
     InputStream requestInputStream =
         new FileInputStream("src/test/resources/room-photos-src/photo1.jpeg");
 
-    requestImage =
+    MockMultipartFile requestImage =
         new MockMultipartFile("photo1", "photo1.jpeg", IMAGE_JPEG_VALUE, requestInputStream);
 
     //when

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
@@ -10,7 +10,6 @@ import com.gurudev.aircnc.domain.member.service.MemberService;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.room.entity.RoomPhoto;
 import com.gurudev.aircnc.domain.util.Command;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,10 +28,12 @@ class RoomServiceImplTest {
   private RoomService roomService;
 
   private Member host;
+
   private Room room1;
   private Room room2;
 
-  private List<RoomPhoto> roomPhotos;
+  private List<RoomPhoto> roomPhotos1;
+  private List<RoomPhoto> roomPhotos2;
 
   @BeforeEach
   void setUp() {
@@ -42,11 +43,8 @@ class RoomServiceImplTest {
     room1 = createRoom();
     room2 = createRoom();
 
-    roomPhotos = List.of(createRoomPhoto(), createRoomPhoto());
-
-    room1 = roomService.register(Command.ofRegisterRoom(room1, roomPhotos, host.getId()));
-    room2 = roomService.register(
-        Command.ofRegisterRoom(room2, Collections.emptyList(), host.getId()));
+    roomPhotos1 = List.of(createRoomPhoto(), createRoomPhoto());
+    roomPhotos2 = List.of(createRoomPhoto());
   }
 
   @Test
@@ -54,15 +52,18 @@ class RoomServiceImplTest {
     Room room = createRoom();
 
     Room registeredRoom = roomService.register(
-        Command.ofRegisterRoom(room, roomPhotos, host.getId()));
+        Command.ofRegisterRoom(room, roomPhotos1, host.getId()));
 
     assertThat(registeredRoom.getId()).isNotNull();
     assertThat(registeredRoom.getHost()).isEqualTo(host);
-    assertThat(registeredRoom.getRoomPhotos()).containsExactlyElementsOf(roomPhotos);
+    assertThat(registeredRoom.getRoomPhotos()).containsExactlyElementsOf(roomPhotos1);
   }
 
   @Test
   void 숙소_리스트_조회_성공() {
+    room1 = roomService.register(Command.ofRegisterRoom(room1, roomPhotos1, host.getId()));
+    room2 = roomService.register(Command.ofRegisterRoom(room2, roomPhotos2, host.getId()));
+
     List<Room> rooms = roomService.getAll();
 
     assertThat(rooms).hasSize(2)

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
@@ -4,6 +4,7 @@ import static com.gurudev.aircnc.domain.util.Fixture.createHost;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoom;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoomPhoto;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.member.service.MemberService;
@@ -18,7 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 class RoomServiceImplTest {
 
   @Autowired

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
@@ -36,7 +36,7 @@ class RoomServiceImplTest {
 
   @BeforeEach
   void setUp() {
-    host = memberService.register(Command.ofHost());
+    host = memberService.register(Command.ofRegisterMember(host));
 
     room1 = createRoom();
     room2 = createRoom();

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.gurudev.aircnc.domain.room.service;
 
-import static com.gurudev.aircnc.domain.util.Command.ofRoom;
+import static com.gurudev.aircnc.domain.util.Fixture.createHost;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoom;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoomPhoto;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +36,7 @@ class RoomServiceImplTest {
 
   @BeforeEach
   void setUp() {
+    host = createHost();
     host = memberService.register(Command.ofRegisterMember(host));
 
     room1 = createRoom();
@@ -43,9 +44,9 @@ class RoomServiceImplTest {
 
     roomPhotos = List.of(createRoomPhoto(), createRoomPhoto());
 
-    room1 = roomService.register(ofRoom(room1, roomPhotos, host.getId()));
+    room1 = roomService.register(Command.ofRegisterRoom(room1, roomPhotos, host.getId()));
     room2 = roomService.register(
-        ofRoom(room2, Collections.emptyList(), host.getId()));
+        Command.ofRegisterRoom(room2, Collections.emptyList(), host.getId()));
   }
 
   @Test
@@ -53,7 +54,7 @@ class RoomServiceImplTest {
     Room room = createRoom();
 
     Room registeredRoom = roomService.register(
-        ofRoom(room, roomPhotos, host.getId()));
+        Command.ofRegisterRoom(room, roomPhotos, host.getId()));
 
     assertThat(registeredRoom.getId()).isNotNull();
     assertThat(registeredRoom.getHost()).isEqualTo(host);

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
@@ -29,44 +29,44 @@ class RoomServiceImplTest {
 
   private Member host;
 
-  private Room room1;
-  private Room room2;
-
-  private List<RoomPhoto> roomPhotos1;
-  private List<RoomPhoto> roomPhotos2;
-
   @BeforeEach
   void setUp() {
     host = createHost();
     host = memberService.register(Command.ofRegisterMember(host));
-
-    room1 = createRoom();
-    room2 = createRoom();
-
-    roomPhotos1 = List.of(createRoomPhoto(), createRoomPhoto());
-    roomPhotos2 = List.of(createRoomPhoto());
   }
 
   @Test
   void 숙소_등록_성공() {
+    //given
     Room room = createRoom();
+    List<RoomPhoto> roomPhotos = List.of(createRoomPhoto(), createRoomPhoto());
 
-    Room registeredRoom = roomService.register(
-        Command.ofRegisterRoom(room, roomPhotos1, host.getId()));
+    //then
+    Room registeredRoom =
+        roomService.register(Command.ofRegisterRoom(room, roomPhotos, host.getId()));
 
+    //then
     assertThat(registeredRoom.getId()).isNotNull();
     assertThat(registeredRoom.getHost()).isEqualTo(host);
-    assertThat(registeredRoom.getRoomPhotos()).containsExactlyElementsOf(roomPhotos1);
+    assertThat(registeredRoom.getRoomPhotos()).containsExactlyElementsOf(roomPhotos);
   }
 
   @Test
   void 숙소_리스트_조회_성공() {
+    //given
+    Room room1 = createRoom();
+    Room room2 = createRoom();
+
+    List<RoomPhoto> roomPhotos1 = List.of(createRoomPhoto(), createRoomPhoto());
+    List<RoomPhoto> roomPhotos2 = List.of(createRoomPhoto(), createRoomPhoto());
+
     room1 = roomService.register(Command.ofRegisterRoom(room1, roomPhotos1, host.getId()));
     room2 = roomService.register(Command.ofRegisterRoom(room2, roomPhotos2, host.getId()));
 
+    //when
     List<Room> rooms = roomService.getAll();
 
-    assertThat(rooms).hasSize(2)
-        .containsExactly(room1, room2);
+    //then
+    assertThat(rooms).hasSize(2).containsExactly(room1, room2);
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
@@ -47,8 +47,10 @@ class TripTest {
 
   @Test
   void Trip_생성_성공() {
+    //when
     Trip trip = new Trip(guest, room, checkIn, checkOut, totalPrice, headCount);
 
+    //then
     assertThat(trip).extracting(Trip::getGuest, Trip::getRoom, Trip::getCheckIn, Trip::getCheckOut,
             Trip::getTotalPrice, Trip::getHeadCount, Trip::getStatus)
         .isEqualTo(List.of(guest, room, checkIn, checkOut, totalPrice, headCount, RESERVED));
@@ -56,58 +58,73 @@ class TripTest {
 
   @Test
   void CheckIn이_CheckOut_이전_이여야_한다() {
+    //given
     LocalDate invalidCheckOut = checkIn.minusDays(1);
 
+    //then
     assertThatIllegalArgumentException()
         .isThrownBy(() -> new Trip(guest, room, checkIn, invalidCheckOut, totalPrice, headCount));
   }
 
   @Test
   void 인원이_제한_인원_이하_일_수_없다() {
+    //given
+    int invalidHeadCount = TRIP_HEADCOUNT_MIN_VALUE - 1;
+
+    //then
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, totalPrice,
-            TRIP_HEADCOUNT_MIN_VALUE - 1));
+        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, totalPrice, invalidHeadCount));
   }
 
   @Test
   void 총_가격은_제한가격_미만일_수_없다() {
+    //given
     int invalidTotalPrice = TRIP_TOTAL_PRICE_MIN_VALUE - 1;
 
+    //then
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, invalidTotalPrice,
-            headCount));
+        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, invalidTotalPrice, headCount));
   }
 
   @Test
   void 계산된_가격과_요청된_가격이_같아야_한다() {
+    //given
     int invalidTotalPrice = this.totalPrice + 1;
 
+    //then
     assertThatExceptionOfType(TripReservationException.class)
         .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, invalidTotalPrice, headCount));
   }
 
   @Test
   void 여행_인원_수는_숙소의_최대_인원을_초과_할_수_없다() {
+    //given
     int invalidCapacity = room.getCapacity() + 1;
 
+    //then
     assertThatExceptionOfType(TripReservationException.class)
         .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, totalPrice, invalidCapacity));
   }
 
   @Test
   void 예약_상태의_여행_취소_성공() {
+    //given
     Trip trip = createTrip();
 
+    //when
     trip.cancel();
 
+    //then
     assertThat(trip.getStatus()).isEqualTo(CANCELLED);
   }
 
   @Test
   void 취소_상태의_여행_취소_실패() {
+    //given
     Trip trip = createTrip();
     trip.cancel(); // -> trip.status = CANCELLED
 
+    //then
     assertThatExceptionOfType(TripCancelException.class)
         .isThrownBy(trip::cancel);
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
@@ -50,45 +50,48 @@ class TripTest {
     Trip trip = new Trip(guest, room, checkIn, checkOut, totalPrice, headCount);
 
     assertThat(trip).extracting(Trip::getGuest, Trip::getRoom, Trip::getCheckIn, Trip::getCheckOut,
-                    Trip::getTotalPrice, Trip::getHeadCount, Trip::getStatus)
-            .isEqualTo(List.of(guest, room, checkIn, checkOut, totalPrice, headCount, RESERVED));
+            Trip::getTotalPrice, Trip::getHeadCount, Trip::getStatus)
+        .isEqualTo(List.of(guest, room, checkIn, checkOut, totalPrice, headCount, RESERVED));
   }
 
   @Test
   void CheckIn이_CheckOut_이전_이여야_한다() {
+    LocalDate invalidCheckOut = checkIn.minusDays(1);
+
     assertThatIllegalArgumentException()
-        .isThrownBy(
-            () -> new Trip(guest, room, checkIn, checkIn.minusDays(1), totalPrice, headCount));
+        .isThrownBy(() -> new Trip(guest, room, checkIn, invalidCheckOut, totalPrice, headCount));
   }
 
   @Test
   void 인원이_제한_인원_이하_일_수_없다() {
     assertThatIllegalArgumentException()
-            .isThrownBy(
-                    () -> new Trip(guest, room, checkIn, checkOut, totalPrice,
-                            TRIP_HEADCOUNT_MIN_VALUE - 1));
+        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, totalPrice,
+            TRIP_HEADCOUNT_MIN_VALUE - 1));
   }
 
   @Test
   void 총_가격은_제한가격_미만일_수_없다() {
+    int invalidTotalPrice = TRIP_TOTAL_PRICE_MIN_VALUE - 1;
+
     assertThatIllegalArgumentException()
-            .isThrownBy(
-                    () -> new Trip(guest, room, checkIn, checkOut, TRIP_TOTAL_PRICE_MIN_VALUE - 1,
-                            headCount));
+        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, invalidTotalPrice,
+            headCount));
   }
 
   @Test
   void 계산된_가격과_요청된_가격이_같아야_한다() {
+    int invalidTotalPrice = this.totalPrice + 1;
+
     assertThatExceptionOfType(TripReservationException.class)
-        .isThrownBy(
-            () -> new Trip(guest, room, checkIn, checkOut, totalPrice + 1, headCount));
+        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, invalidTotalPrice, headCount));
   }
 
   @Test
   void 여행_인원_수는_숙소의_최대_인원을_초과_할_수_없다() {
+    int invalidCapacity = room.getCapacity() + 1;
+
     assertThatExceptionOfType(TripReservationException.class)
-            .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, totalPrice,
-                    room.getCapacity() + 1));
+        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, totalPrice, invalidCapacity));
   }
 
   @Test

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
@@ -68,9 +68,6 @@ class TripServiceImplTest {
     checkOut = now().plusDays(2);
     headCount = room.getCapacity();
     totalPrice = between(checkIn, checkOut).getDays() * room.getPricePerDay();
-
-    trip1 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
-    trip2 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
   }
 
   @Test
@@ -86,6 +83,9 @@ class TripServiceImplTest {
 
   @Test
   void 게스트의_여행_목록_조회() {
+    trip1 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
+    trip2 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
+
     List<Trip> findTrips = tripService.getByGuest(guest);
 
     assertThat(findTrips).hasSize(2).containsExactly(trip1, trip2);
@@ -93,6 +93,8 @@ class TripServiceImplTest {
 
   @Test
   void 여행_상세_조회() {
+    trip1 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
+
     Trip trip = tripService.getById(trip1.getId());
 
     assertThat(trip).isEqualTo(trip1);
@@ -111,7 +113,10 @@ class TripServiceImplTest {
 
   @Test
   void 예약_상태의_여행_취소_성공() {
-    Trip cancelledTrip = tripService.cancel(trip1.getId());
+    Trip reservedTrip =
+        tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
+
+    Trip cancelledTrip = tripService.cancel(reservedTrip.getId());
 
     assertThat(cancelledTrip.getStatus()).isEqualTo(CANCELLED);
   }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
@@ -2,7 +2,7 @@ package com.gurudev.aircnc.domain.trip.service;
 
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.CANCELLED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.RESERVED;
-import static com.gurudev.aircnc.domain.util.Command.ofRoom;
+import static com.gurudev.aircnc.domain.util.Fixture.createGuest;
 import static com.gurudev.aircnc.domain.util.Fixture.createHost;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoom;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoomPhoto;
@@ -57,9 +57,10 @@ class TripServiceImplTest {
   void setUp() {
     Member host = memberService.register(Command.ofRegisterMember(createHost()));
 
+    guest = createGuest();
     room = createRoom();
     roomPhoto = createRoomPhoto();
-    room = roomService.register(ofRoom(room, List.of(roomPhoto), host.getId()));
+    room = roomService.register(Command.ofRegisterRoom(room, List.of(roomPhoto), host.getId()));
 
     guest = memberService.register(Command.ofRegisterMember(guest));
 

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
@@ -2,8 +2,8 @@ package com.gurudev.aircnc.domain.trip.service;
 
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.CANCELLED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.RESERVED;
-import static com.gurudev.aircnc.domain.util.Command.ofGuest;
 import static com.gurudev.aircnc.domain.util.Command.ofRoom;
+import static com.gurudev.aircnc.domain.util.Fixture.createHost;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoom;
 import static com.gurudev.aircnc.domain.util.Fixture.createRoomPhoto;
 import static com.gurudev.aircnc.util.AssertionUtil.assertThatNotFoundException;
@@ -55,13 +55,13 @@ class TripServiceImplTest {
 
   @BeforeEach
   void setUp() {
-    Member host = memberService.register(Command.ofHost());
+    Member host = memberService.register(Command.ofRegisterMember(createHost()));
 
     room = createRoom();
     roomPhoto = createRoomPhoto();
     room = roomService.register(ofRoom(room, List.of(roomPhoto), host.getId()));
 
-    guest = memberService.register(ofGuest());
+    guest = memberService.register(Command.ofRegisterMember(guest));
 
     checkIn = now().plusDays(1);
     checkOut = now().plusDays(2);

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
@@ -50,9 +50,6 @@ class TripServiceImplTest {
   private int headCount;
   private int totalPrice;
 
-  private Trip trip1;
-  private Trip trip2;
-
   @BeforeEach
   void setUp() {
     Member host = memberService.register(Command.ofRegisterMember(createHost()));
@@ -72,9 +69,10 @@ class TripServiceImplTest {
 
   @Test
   void 여행_생성_성공() {
-    Trip trip = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount,
-        totalPrice);
+    //when
+    Trip trip = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
 
+    //then
     assertThat(trip.getId()).isNotNull();
     assertThat(trip).extracting(Trip::getGuest, Trip::getRoom, Trip::getCheckIn, Trip::getCheckOut,
             Trip::getTotalPrice, Trip::getHeadCount, Trip::getStatus)
@@ -83,20 +81,26 @@ class TripServiceImplTest {
 
   @Test
   void 게스트의_여행_목록_조회() {
-    trip1 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
-    trip2 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
+    //given
+    Trip trip1 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
+    Trip trip2 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
 
+    //when
     List<Trip> findTrips = tripService.getByGuest(guest);
 
+    //then
     assertThat(findTrips).hasSize(2).containsExactly(trip1, trip2);
   }
 
   @Test
   void 여행_상세_조회() {
-    trip1 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
+    //given
+    Trip trip1 = tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
 
+    //when
     Trip trip = tripService.getById(trip1.getId());
 
+    //then
     assertThat(trip).isEqualTo(trip1);
     assertThat(trip.getGuest()).isEqualTo(guest);
     assertThat(trip.getRoom()).isEqualTo(room);
@@ -105,19 +109,24 @@ class TripServiceImplTest {
 
   @Test
   void 없는_아이디로_여행_상세_조회_실패() {
+    //given
     Long invalidTripId = -1L;
 
+    //then
     assertThatNotFoundException()
         .isThrownBy(() -> tripService.getById(invalidTripId));
   }
 
   @Test
   void 예약_상태의_여행_취소_성공() {
+    //given
     Trip reservedTrip =
         tripService.reserve(guest, room.getId(), checkIn, checkOut, headCount, totalPrice);
 
+    //when
     Trip cancelledTrip = tripService.cancel(reservedTrip.getId());
 
+    //then
     assertThat(cancelledTrip.getStatus()).isEqualTo(CANCELLED);
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/TripServiceImplTest.java
@@ -10,6 +10,7 @@ import static com.gurudev.aircnc.util.AssertionUtil.assertThatNotFoundException;
 import static java.time.LocalDate.now;
 import static java.time.Period.between;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.member.service.MemberService;
@@ -27,7 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 class TripServiceImplTest {
 
   @Autowired

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/util/Command.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/util/Command.java
@@ -1,33 +1,26 @@
 package com.gurudev.aircnc.domain.util;
 
 import com.gurudev.aircnc.controller.dto.RoomDto.RoomRegisterRequest;
-import com.gurudev.aircnc.domain.member.entity.Role;
+import com.gurudev.aircnc.domain.member.entity.Email;
+import com.gurudev.aircnc.domain.member.entity.Member;
+import com.gurudev.aircnc.domain.member.entity.Password;
+import com.gurudev.aircnc.domain.member.entity.PhoneNumber;
 import com.gurudev.aircnc.domain.member.service.command.MemberCommand.MemberRegisterCommand;
 import com.gurudev.aircnc.domain.room.entity.Address;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.room.entity.RoomPhoto;
 import com.gurudev.aircnc.domain.room.service.command.RoomCommand.RoomRegisterCommand;
-import java.time.LocalDate;
 import java.util.List;
 
 public class Command {
 
-  public static MemberRegisterCommand ofHost() {
-    return new MemberRegisterCommand("host@haha.com",
-        "paSSword!",
-        "ndy",
-        LocalDate.of(1997, 8, 21),
-        "010-1234-5678",
-        Role.HOST.name());
-  }
-
-  public static MemberRegisterCommand ofGuest() {
-    return new MemberRegisterCommand("guest@haha.com",
-        "paSSword!",
-        "ndy",
-        LocalDate.of(1997, 8, 21),
-        "010-1234-5678",
-        Role.GUEST.name());
+  public static MemberRegisterCommand ofRegisterMember(Member member) {
+    return new MemberRegisterCommand(Email.toString(member.getEmail()),
+        Password.toString(member.getPassword()),
+        member.getName(),
+        member.getBirthDate(),
+        PhoneNumber.toString(member.getPhoneNumber()),
+        member.getRole().name());
   }
 
   public static RoomRegisterCommand ofRoom(Room room, List<RoomPhoto> roomPhotos,

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/util/Command.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/util/Command.java
@@ -23,7 +23,7 @@ public class Command {
         member.getRole().name());
   }
 
-  public static RoomRegisterCommand ofRoom(Room room, List<RoomPhoto> roomPhotos,
+  public static RoomRegisterCommand ofRegisterRoom(Room room, List<RoomPhoto> roomPhotos,
       Long hostId) {
     Address address = room.getAddress();
     RoomRegisterRequest request = new RoomRegisterRequest(


### PR DESCRIPTION
## 🛠️ 작업 내용
- 테스트 코드 `Command` static 클래스의 적용 방식 변경
- 테스트 대상이 되는 객체의 세팅은 최대한 `@Test` 안쪽으로 밀어 넣도록 변경
- `given/when/then `주석 적용
- 필드 리터럴 세팅 `@BeforeEach` 로 이동 
   - 이걸 전부 각 테스트에 쓰려니까 엔티티에서  공백이나 글자 수 같은 테스트에서 코드 뻥튀기가 너무 심하네요.
   - `given` 에 해당되는 녀석들이라 필드에서 세팅하는 것보다 `@BeforeEach` 셋업 메서드에서 생성하는 것이 좋다고 생각해서 이런식으로 써보았습니다. 의견이 궁금하네요
-  줄이 늘어지는 경우에 라인이 으게질때 `=` 이후에 줄바꿈을 하나씩 줘보니 좋은거 같네요
``` java
requestImage = new MockMultipartFile("photo1", "photo1.jpeg", IMAGE_JPEG_VALUE,
        requestInputStream);
```
대신
``` java
MockMultipartFile requestImage =
        new MockMultipartFile("photo1", "photo1.jpeg", IMAGE_JPEG_VALUE, requestInputStream);
```
이렇게요
