### PR TITLE
[AIR-135] 이메일 기능 피드백 반영 & 리팩토링

### DIFF
--- a/aircnc/src/main/java/com/gurudev/aircnc/controller/EmailAuthController.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/controller/EmailAuthController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/emails")
 @RequiredArgsConstructor
-public class EmailController {
+public class EmailAuthController {
 
   private final EmailService memberEmailService;
 

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/room/entity/Room.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/room/entity/Room.java
@@ -10,7 +10,6 @@ import com.gurudev.aircnc.domain.base.BaseIdEntity;
 import com.gurudev.aircnc.domain.member.entity.Member;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -115,13 +114,5 @@ public class Room extends BaseIdEntity {
     Optional.ofNullable(pricePerDay).ifPresent(this::setPricePerDay);
 
     return this;
-  }
-
-  public Map<String, Object> toMap() {
-    return Map.of("name", name,
-        "address", Address.toString(address),
-        "description", description,
-        "pricePerDay", pricePerDay,
-        "capacity", capacity);
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/room/service/RoomServiceImpl.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/room/service/RoomServiceImpl.java
@@ -2,6 +2,7 @@ package com.gurudev.aircnc.domain.room.service;
 
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.RESERVED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.TRAVELLING;
+import static com.gurudev.aircnc.domain.utils.MapUtils.toMap;
 import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
 
 import com.gurudev.aircnc.domain.member.entity.Email;
@@ -43,7 +44,7 @@ public class RoomServiceImpl implements RoomService {
         .orElseThrow(() -> new NotFoundException(Member.class));
 
     room.assignHost(host);
-    roomEmailService.send(Email.toString(host.getEmail()), room.toMap(), MailType.REGISTER);
+    roomEmailService.send(Email.toString(host.getEmail()), toMap(room), MailType.REGISTER);
     return roomRepository.save(room);
   }
 
@@ -61,7 +62,7 @@ public class RoomServiceImpl implements RoomService {
 
     Member host = room.getHost();
 
-    roomEmailService.send(Email.toString(host.getEmail()), room.toMap(), MailType.UPDATE);
+    roomEmailService.send(Email.toString(host.getEmail()), toMap(room), MailType.UPDATE);
     return room.update(roomUpdateCommand.getName(), roomUpdateCommand.getDescription(),
         roomUpdateCommand.getPricePerDay());
   }
@@ -69,14 +70,14 @@ public class RoomServiceImpl implements RoomService {
   @Transactional
   @Override
   public void delete(RoomDeleteCommand roomDeleteCommand) {
-    Room findRoom = roomRepository.findById(roomDeleteCommand.getRoomId())
+    Room room = roomRepository.findById(roomDeleteCommand.getRoomId())
         .orElseThrow(() -> new NotFoundException(Room.class));
 
-    checkArgument(isDeletable(findRoom.getHost().getId(), roomDeleteCommand.getRoomId(),
+    checkArgument(isDeletable(room.getHost().getId(), roomDeleteCommand.getRoomId(),
         roomDeleteCommand.getHostId()), "숙소를 삭제 할 수 없습니다");
 
-    Member host = findRoom.getHost();
-    roomEmailService.send(Email.toString(host.getEmail()), findRoom.toMap(), MailType.DELETE);
+    Member host = room.getHost();
+    roomEmailService.send(Email.toString(host.getEmail()), toMap(room), MailType.DELETE);
     roomRepository.deleteById(roomDeleteCommand.getRoomId());
   }
 

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/Trip.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/Trip.java
@@ -14,7 +14,6 @@ import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.exception.TripCancelException;
 import java.time.LocalDate;
-import java.util.Map;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.ManyToOne;
@@ -99,13 +98,4 @@ public class Trip extends BaseIdEntity {
 
     this.status = CANCELLED;
   }
-
-  public Map<String, Object> toMap() {
-    return Map.of("checkIn", checkIn,
-        "checkOut", checkOut,
-        "totalPrice", totalPrice,
-        "headCount", headCount,
-        "status", status);
-  }
-
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/service/TripServiceImpl.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/service/TripServiceImpl.java
@@ -1,7 +1,8 @@
 package com.gurudev.aircnc.domain.trip.service;
 
-import static java.time.LocalDate.*;
-import static java.util.stream.Collectors.*;
+import static com.gurudev.aircnc.domain.utils.MapUtils.toMap;
+import static java.time.LocalDate.now;
+import static java.util.stream.Collectors.toList;
 
 import com.gurudev.aircnc.domain.member.entity.Email;
 import com.gurudev.aircnc.domain.member.entity.Member;
@@ -40,7 +41,6 @@ public class TripServiceImpl implements TripService {
 
     //TODO: 예약 겹치는지 검증 로직 필요
 
-    tripEmailService.send(Email.toString(guest.getEmail()), room.toMap(), MailType.REGISTER);
     return tripRepository.save(
         new Trip(guest, room,
             tripEvent.getCheckIn(),
@@ -69,7 +69,7 @@ public class TripServiceImpl implements TripService {
     trip.cancel();
 
     Member guest = trip.getGuest();
-    tripEmailService.send(Email.toString(guest.getEmail()), trip.toMap(), MailType.DELETE);
+    tripEmailService.send(Email.toString(guest.getEmail()), toMap(trip), MailType.DELETE);
     return trip;
   }
 

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/utils/MapUtils.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/utils/MapUtils.java
@@ -3,6 +3,7 @@ package com.gurudev.aircnc.domain.utils;
 import com.gurudev.aircnc.domain.room.entity.Address;
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.trip.entity.Trip;
+import com.gurudev.aircnc.infrastructure.event.TripEvent;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -25,5 +26,14 @@ public final class MapUtils {
         "totalPrice", trip.getTotalPrice(),
         "headCount", trip.getHeadCount(),
         "status", trip.getStatus());
+  }
+
+  public static Map<String, Object> toMap(TripEvent tripEvent) {
+    return Map.of(
+        "checkIn", tripEvent.getCheckIn(),
+        "checkOut", tripEvent.getCheckOut(),
+        "totalPrice", tripEvent.getTotalPrice(),
+        "headCount", tripEvent.getHeadCount(),
+        "status", tripEvent.getStatus());
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/utils/MapUtils.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/utils/MapUtils.java
@@ -1,0 +1,29 @@
+package com.gurudev.aircnc.domain.utils;
+
+import com.gurudev.aircnc.domain.room.entity.Address;
+import com.gurudev.aircnc.domain.room.entity.Room;
+import com.gurudev.aircnc.domain.trip.entity.Trip;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MapUtils {
+
+  public static Map<String, Object> toMap(Room room) {
+    return Map.of("name", room.getName(),
+        "address", Address.toString(room.getAddress()),
+        "description", room.getDescription(),
+        "pricePerDay", room.getPricePerDay(),
+        "capacity", room.getCapacity());
+  }
+
+  public static Map<String, Object> toMap(Trip trip) {
+    return Map.of(
+        "checkIn", trip.getCheckIn(),
+        "checkOut", trip.getCheckOut(),
+        "totalPrice", trip.getTotalPrice(),
+        "headCount", trip.getHeadCount(),
+        "status", trip.getStatus());
+  }
+}

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/event/TripEventRunner.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/event/TripEventRunner.java
@@ -1,6 +1,13 @@
 package com.gurudev.aircnc.infrastructure.event;
 
+import static com.gurudev.aircnc.domain.utils.MapUtils.toMap;
+
+import com.gurudev.aircnc.domain.member.entity.Email;
+import com.gurudev.aircnc.domain.member.entity.Member;
+import com.gurudev.aircnc.domain.member.service.MemberService;
 import com.gurudev.aircnc.domain.trip.service.TripService;
+import com.gurudev.aircnc.infrastructure.mail.entity.MailType;
+import com.gurudev.aircnc.infrastructure.mail.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,6 +20,9 @@ public class TripEventRunner implements Runnable {
 
   private final TripEventQueue eventQueue;
   private final TripService tripService;
+  private final MemberService memberService;
+  private final EmailService tripEmailService;
+
 
   @Override
   public void run() {
@@ -29,11 +39,15 @@ public class TripEventRunner implements Runnable {
 
   private void handlingInCaseOfSuccess(TripEvent tripEvent) {
     log.info("여행이 예약되었습니다! ");
-    // TODO 예약 성공 메일 보내기
+
+    Member member = memberService.getById(tripEvent.getGuestId());
+    tripEmailService.send(Email.toString(member.getEmail()), toMap(tripEvent), MailType.REGISTER);
   }
 
   private void handlingInCaseOfFailure(TripEvent tripEvent) {
     log.info("여행 예약이 실패하였습니다! ");
-    // TODO 예약 실패 메일 보내기
+
+    Member member = memberService.getById(tripEvent.getGuestId());
+    tripEmailService.send(Email.toString(member.getEmail()), toMap(tripEvent), MailType.FAIL);
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/event/TripEventRunner.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/event/TripEventRunner.java
@@ -30,21 +30,21 @@ public class TripEventRunner implements Runnable {
       TripEvent tripEvent = eventQueue.poll();
       try {
         tripService.reserve(tripEvent);
-        handlingInCaseOfSuccess(tripEvent);
+        handleSuccess(tripEvent);
       } catch (Exception e) {
-        handlingInCaseOfFailure(tripEvent);
+        handleFailure(tripEvent);
       }
     }
   }
 
-  private void handlingInCaseOfSuccess(TripEvent tripEvent) {
+  private void handleSuccess(TripEvent tripEvent) {
     log.info("여행이 예약되었습니다! ");
 
     Member member = memberService.getById(tripEvent.getGuestId());
     tripEmailService.send(Email.toString(member.getEmail()), toMap(tripEvent), MailType.REGISTER);
   }
 
-  private void handlingInCaseOfFailure(TripEvent tripEvent) {
+  private void handleFailure(TripEvent tripEvent) {
     log.info("여행 예약이 실패하였습니다! ");
 
     Member member = memberService.getById(tripEvent.getGuestId());

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/event/TripEventScheduler.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/event/TripEventScheduler.java
@@ -1,6 +1,8 @@
 package com.gurudev.aircnc.infrastructure.event;
 
+import com.gurudev.aircnc.domain.member.service.MemberService;
 import com.gurudev.aircnc.domain.trip.service.TripService;
+import com.gurudev.aircnc.infrastructure.mail.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -15,11 +17,13 @@ public class TripEventScheduler {
 
   private final TripEventQueue eventQueue;
   private final TripService tripService;
+  private final MemberService memberService;
+  private final EmailService tripEmailService;
 
   @Async("taskScheduler")
   @Scheduled(fixedRate = 100)
   public void tripReserveSchedule() {
-    new TripEventRunner(eventQueue, tripService)
+    new TripEventRunner(eventQueue, tripService, memberService, tripEmailService)
         .run();
   }
 

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/entity/EmailAuthKey.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/entity/EmailAuthKey.java
@@ -2,6 +2,7 @@ package com.gurudev.aircnc.infrastructure.mail.entity;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -20,18 +21,21 @@ public class EmailAuthKey {
   private Long id;
 
   @Column(unique = true, length = 8, nullable = false)
-  private String key;
+  private String authKey;
 
   @Column(nullable = false)
   private String email;
 
-  public EmailAuthKey(String key, String email) {
-    this.key = key;
+  private LocalDateTime createdAt;
+
+  public EmailAuthKey(String authKey, String email) {
+    this.authKey = authKey;
     this.email = email;
+    this.createdAt = LocalDateTime.now();
   }
 
   public boolean validateKey(String key) {
-    return this.key.equals(key);
+    return this.authKey.equals(key);
   }
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/entity/MailType.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/entity/MailType.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum MailType {
   REGISTER("등록"),
   UPDATE("변경"),
-  DELETE("삭제");
+  DELETE("삭제"),
+
+  FAIL("실패");
 
   private final String status;
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/repository/EmailAuthKeyRepository.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/repository/EmailAuthKeyRepository.java
@@ -1,7 +1,7 @@
 package com.gurudev.aircnc.infrastructure.mail.repository;
 
 import com.gurudev.aircnc.infrastructure.mail.entity.EmailAuthKey;
-import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EmailAuthKeyRepository extends JpaRepository<EmailAuthKey, Long> {
 
-    List<EmailAuthKey> findByEmail(String email, Sort sort);
+    Optional<EmailAuthKey> findTopByEmail(String email, Sort sort);
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/repository/EmailAuthKeyRepository.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/repository/EmailAuthKeyRepository.java
@@ -1,13 +1,14 @@
 package com.gurudev.aircnc.infrastructure.mail.repository;
 
 import com.gurudev.aircnc.infrastructure.mail.entity.EmailAuthKey;
-import java.util.Optional;
+import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EmailAuthKeyRepository extends JpaRepository<EmailAuthKey, Long> {
 
-  Optional<EmailAuthKey> findByEmail(String email);
+    List<EmailAuthKey> findByEmail(String email, Sort sort);
 
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/AbstractEmailService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/AbstractEmailService.java
@@ -2,7 +2,6 @@ package com.gurudev.aircnc.infrastructure.mail.service;
 
 import com.gurudev.aircnc.infrastructure.mail.entity.MailType;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.mail.internet.InternetAddress;
@@ -52,10 +51,8 @@ public abstract class AbstractEmailService implements EmailService {
     }
   }
 
-  protected Map<String, Object> putMailKind(Map<String, Object> map, MailType mailKind) {
-    Map<String, Object> addedMap = new HashMap<>(map);
-    addedMap.put("behavior", mailKind.getStatus());
-    return addedMap;
+  protected String getTemplateName(MailType mailType, String TEMPLATE_PREFIX) {
+    return TEMPLATE_PREFIX + mailType.name().toLowerCase();
   }
 
   private String getContent(Map<String, Object> contentMap, String templateName) {

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/AbstractEmailService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/AbstractEmailService.java
@@ -51,8 +51,8 @@ public abstract class AbstractEmailService implements EmailService {
     }
   }
 
-  protected String getTemplateName(MailType mailType, String TEMPLATE_PREFIX) {
-    return TEMPLATE_PREFIX + mailType.name().toLowerCase();
+  protected String getTemplateName(MailType mailType, String templatePrefix) {
+    return templatePrefix + mailType.name().toLowerCase();
   }
 
   private String getContent(Map<String, Object> contentMap, String templateName) {

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/MemberEmailService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/MemberEmailService.java
@@ -3,8 +3,8 @@ package com.gurudev.aircnc.infrastructure.mail.service;
 import com.gurudev.aircnc.infrastructure.mail.entity.EmailAuthKey;
 import com.gurudev.aircnc.infrastructure.mail.entity.MailType;
 import com.gurudev.aircnc.infrastructure.mail.repository.EmailAuthKeyRepository;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -64,12 +64,12 @@ public class MemberEmailService extends AbstractEmailService {
   }
 
   public boolean validateKey(String AuthKey, String email) {
-    List<EmailAuthKey> keyList = emailAuthKeyRepository.findByEmail(
+    Optional<EmailAuthKey> keyList = emailAuthKeyRepository.findTopByEmail(
         email, Sort.by(Direction.DESC, "createdAt"));
     if (keyList.isEmpty()) {
       return false;
     }
-    EmailAuthKey latestKey = keyList.get(0);
+    EmailAuthKey latestKey = keyList.get();
     return latestKey.validateKey(AuthKey);
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/MemberEmailService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/MemberEmailService.java
@@ -64,8 +64,8 @@ public class MemberEmailService extends AbstractEmailService {
   }
 
   public boolean validateKey(String AuthKey, String email) {
-    List<EmailAuthKey> keyList = emailAuthKeyRepository.findByEmail(email,
-        Sort.by(Direction.DESC, "createdAt"));
+    List<EmailAuthKey> keyList = emailAuthKeyRepository.findByEmail(
+        email, Sort.by(Direction.DESC, "createdAt"));
     if (keyList.isEmpty()) {
       return false;
     }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/MemberEmailService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/MemberEmailService.java
@@ -3,9 +3,11 @@ package com.gurudev.aircnc.infrastructure.mail.service;
 import com.gurudev.aircnc.infrastructure.mail.entity.EmailAuthKey;
 import com.gurudev.aircnc.infrastructure.mail.entity.MailType;
 import com.gurudev.aircnc.infrastructure.mail.repository.EmailAuthKeyRepository;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -62,10 +64,12 @@ public class MemberEmailService extends AbstractEmailService {
   }
 
   public boolean validateKey(String AuthKey, String email) {
-    Optional<EmailAuthKey> keyOptional = emailAuthKeyRepository.findByEmail(email);
-    if (keyOptional.isEmpty()) {
+    List<EmailAuthKey> keyList = emailAuthKeyRepository.findByEmail(email,
+        Sort.by(Direction.DESC, "createdAt"));
+    if (keyList.isEmpty()) {
       return false;
     }
-    return keyOptional.get().validateKey(AuthKey);
+    EmailAuthKey latestKey = keyList.get(0);
+    return latestKey.validateKey(AuthKey);
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/MemberEmailService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/MemberEmailService.java
@@ -4,6 +4,7 @@ import com.gurudev.aircnc.infrastructure.mail.entity.EmailAuthKey;
 import com.gurudev.aircnc.infrastructure.mail.entity.MailType;
 import com.gurudev.aircnc.infrastructure.mail.repository.EmailAuthKeyRepository;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -61,8 +62,10 @@ public class MemberEmailService extends AbstractEmailService {
   }
 
   public boolean validateKey(String AuthKey, String email) {
-    EmailAuthKey key = emailAuthKeyRepository.findByEmail(email)
-        .orElseThrow(() -> new RuntimeException("해당 인증키가 존재하지 않습니다"));
-    return key.validateKey(AuthKey);
+    Optional<EmailAuthKey> keyOptional = emailAuthKeyRepository.findByEmail(email);
+    if (keyOptional.isEmpty()) {
+      return false;
+    }
+    return keyOptional.get().validateKey(AuthKey);
   }
 }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/RoomEmailService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/RoomEmailService.java
@@ -12,7 +12,7 @@ import org.thymeleaf.spring5.SpringTemplateEngine;
 @Service
 public class RoomEmailService extends AbstractEmailService {
 
-  private static final String TEMPLATE_NAME = "room-template";
+  private static final String TEMPLATE_PREFIX = "room-";
 
   protected RoomEmailService(SpringTemplateEngine springTemplateEngine,
       JavaMailSender emailSender) {
@@ -20,13 +20,11 @@ public class RoomEmailService extends AbstractEmailService {
   }
 
   @Override
-  public void send(String receiverEmail, Map<String, Object> contentMap, MailType mailKind) {
-    String title = format("AirCnc 숙소 %s 알림", mailKind.getStatus());
-
-    Map<String, Object> contents = putMailKind(contentMap, mailKind);
-
+  public void send(String receiverEmail, Map<String, Object> contentMap, MailType mailType) {
+    String title = format("AirCnc 숙소 %s 알림", mailType.getStatus());
     try {
-      emailSender.send(createMessage(receiverEmail, contents, title, TEMPLATE_NAME));
+      emailSender.send(createMessage(receiverEmail, contentMap, title,
+          getTemplateName(mailType, TEMPLATE_PREFIX)));
     } catch (MailException ex) {
       throw new RuntimeException("메일 전송에 실패하였습니다", ex);
     }

--- a/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/TripEmailService.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/infrastructure/mail/service/TripEmailService.java
@@ -12,7 +12,7 @@ import org.thymeleaf.spring5.SpringTemplateEngine;
 @Service
 public class TripEmailService extends AbstractEmailService {
 
-  private static final String TEMPLATE_NAME = "trip-template";
+  private static final String TEMPLATE_PREFIX = "trip-";
 
   protected TripEmailService(SpringTemplateEngine springTemplateEngine,
       JavaMailSender emailSender) {
@@ -23,14 +23,11 @@ public class TripEmailService extends AbstractEmailService {
   public void send(String receiverEmail, Map<String, Object> contentMap, MailType mailKind) {
     String title = format("AirCnc 여행 %s 알림", mailKind.getStatus());
 
-    Map<String, Object> contents = putMailKind(contentMap, mailKind);
-
     try {
-      emailSender.send(createMessage(receiverEmail, contents, title, TEMPLATE_NAME));
+      emailSender.send(createMessage(receiverEmail, contentMap, title,
+          getTemplateName(mailKind, TEMPLATE_PREFIX)));
     } catch (MailException ex) {
       throw new RuntimeException("메일 전송에 실패하였습니다", ex);
     }
-
-
   }
 }

--- a/aircnc/src/main/resources/mail-templates/room-delete.html
+++ b/aircnc/src/main/resources/mail-templates/room-delete.html
@@ -3,8 +3,8 @@
 <div style='margin:100px;'></div>
 <h1> 안녕하세요 AirCnC 입니다. </h1>
 <br>
-<p th:text="|숙소가 ${behavior} 되었습니다.|">
-  <br>
+<p>숙소가 삭제 되었습니다.</p>
+<br>
 <p>감사합니다!
   <br>
 <div text-align='center' style='border:1px solid black; font-family:verdana,serif'></div>

--- a/aircnc/src/main/resources/mail-templates/room-register.html
+++ b/aircnc/src/main/resources/mail-templates/room-register.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<div style='margin:100px;'></div>
+<h1> 안녕하세요 AirCnC 입니다. </h1>
+<br>
+<p>숙소가 등록 되었습니다.</p>
+<br>
+<p>감사합니다!
+  <br>
+<div text-align='center' style='border:1px solid black; font-family:verdana,serif'></div>
+<h3 style='color:blue;'> 숙소 상세 정보</h3>
+<div style='font-size:130%'>
+  <strong th:text="|숙소이름 : ${name}|"></strong><br>
+  <strong th:text="|주소 : ${address}|"></strong><br>
+  <strong th:text="|1박당 가격 : ${pricePerDay}|"></strong><br>
+</div>
+</html>

--- a/aircnc/src/main/resources/mail-templates/room-update.html
+++ b/aircnc/src/main/resources/mail-templates/room-update.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<div style='margin:100px;'></div>
+<h1> 안녕하세요 AirCnC 입니다. </h1>
+<br>
+<p>숙소가 변경 되었습니다.</p>
+<br>
+<p>감사합니다!
+  <br>
+<div text-align='center' style='border:1px solid black; font-family:verdana,serif'></div>
+<h3 style='color:blue;'> 숙소 상세 정보</h3>
+<div style='font-size:130%'>
+  <strong th:text="|숙소이름 : ${name}|"></strong><br>
+  <strong th:text="|주소 : ${address}|"></strong><br>
+  <strong th:text="|1박당 가격 : ${pricePerDay}|"></strong><br>
+</div>
+</html>

--- a/aircnc/src/main/resources/mail-templates/trip-delete.html
+++ b/aircnc/src/main/resources/mail-templates/trip-delete.html
@@ -3,8 +3,8 @@
 <div style='margin:100px;'></div>
 <h1> 안녕하세요 AirCnC 입니다. </h1>
 <br>
-<p th:text="|여행이 ${behavior} 되었습니다.|">
-  <br>
+<p>여행 예약이 취소 되었습니다.</p>
+<br>
 <p>감사합니다!
   <br>
 <div text-align='center' style='border:1px solid black; font-family:verdana,serif'></div>

--- a/aircnc/src/main/resources/mail-templates/trip-fail.html
+++ b/aircnc/src/main/resources/mail-templates/trip-fail.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<div style='margin:100px;'></div>
+<h1> 안녕하세요 AirCnC 입니다. </h1>
+<br>
+<p>여행 예약에 오류가 발생했습니다.</p>
+<br>
+<p>감사합니다!
+  <br>
+<div text-align='center' style='border:1px solid black; font-family:verdana,serif'></div>
+<h3 style='color:blue;'> 여행 상세 정보</h3>
+<div style='font-size:130%'>
+  <strong th:text="|여행기간 : ${checkIn + '~' + checkOut}|"></strong><br>
+  <strong th:text="|총 가격 : ${totalPrice}|"></strong><br>
+  <strong th:text="|인원 수 : ${headCount}|"></strong><br>
+</div>
+</html>

--- a/aircnc/src/main/resources/mail-templates/trip-register.html
+++ b/aircnc/src/main/resources/mail-templates/trip-register.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<div style='margin:100px;'></div>
+<h1> 안녕하세요 AirCnC 입니다. </h1>
+<br>
+<p>여행이 예약 되었습니다.</p>
+<br>
+<p>감사합니다!
+  <br>
+<div text-align='center' style='border:1px solid black; font-family:verdana,serif'></div>
+<h3 style='color:blue;'> 여행 상세 정보</h3>
+<div style='font-size:130%'>
+  <strong th:text="|여행기간 : ${checkIn + '~' + checkOut}|"></strong><br>
+  <strong th:text="|총 가격 : ${totalPrice}|"></strong><br>
+  <strong th:text="|인원 수 : ${headCount}|"></strong><br>
+</div>
+</html>

--- a/aircnc/src/test/java/com/gurudev/aircnc/infrastructure/mail/EmailServiceTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/infrastructure/mail/EmailServiceTest.java
@@ -1,5 +1,7 @@
 package com.gurudev.aircnc.infrastructure.mail;
 
+import static com.gurudev.aircnc.domain.utils.MapUtils.toMap;
+
 import com.gurudev.aircnc.domain.room.entity.Room;
 import com.gurudev.aircnc.domain.trip.entity.Trip;
 import com.gurudev.aircnc.domain.util.Fixture;
@@ -18,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 @Disabled
 class EmailServiceTest { // 사용방법을 위한 Temporary 테스트
 
+
   @Autowired
   @Qualifier("memberEmailService")
   private EmailService memberEmailService;
@@ -29,6 +32,7 @@ class EmailServiceTest { // 사용방법을 위한 Temporary 테스트
   @Autowired
   @Qualifier("tripEmailService")
   private EmailService tripEmailService;
+
 
   private Room room;
 
@@ -50,28 +54,28 @@ class EmailServiceTest { // 사용방법을 위한 Temporary 테스트
   @Test
   void 숙소_삭제_이메일_전송_테스트() throws InterruptedException {
     roomEmailService.send("rlfrmsdh1@gmail.com",
-        room.toMap(), MailType.DELETE);
-    Thread.sleep(5000); // 비동기여서 전송될때까지 기다려주는 로직
+        toMap(room), MailType.DELETE);
+    Thread.sleep(5000);
   }
 
   @Test
   void 숙소_등록_이메일_전송_테스트() throws InterruptedException {
     roomEmailService.send("rlfrmsdh1@gmail.com",
-        room.toMap(), MailType.REGISTER);
+        toMap(room), MailType.REGISTER);
     Thread.sleep(5000);
   }
 
   @Test
   void 숙소_변경_이메일_전송_테스트() throws InterruptedException {
     roomEmailService.send("rlfrmsdh1@gmail.com",
-        room.toMap(), MailType.UPDATE);
+        toMap(room), MailType.UPDATE);
     Thread.sleep(5000);
   }
 
   @Test
   void 여행_변경_이메일_전송_테스트() throws InterruptedException {
     tripEmailService.send("rlfrmsdh1@gmail.com",
-        trip.toMap(), MailType.UPDATE);
+        toMap(trip), MailType.UPDATE);
     Thread.sleep(5000);
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/infrastructure/mail/EmailServiceTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/infrastructure/mail/EmailServiceTest.java
@@ -73,9 +73,23 @@ class EmailServiceTest { // 사용방법을 위한 Temporary 테스트
   }
 
   @Test
-  void 여행_변경_이메일_전송_테스트() throws InterruptedException {
+  void 여행_등록_이메일_전송_테스트() throws InterruptedException {
     tripEmailService.send("rlfrmsdh1@gmail.com",
-        toMap(trip), MailType.UPDATE);
+        toMap(trip), MailType.REGISTER);
+    Thread.sleep(5000);
+  }
+
+  @Test
+  void 여행_취소_이메일_전송_테스트() throws InterruptedException {
+    tripEmailService.send("rlfrmsdh1@gmail.com",
+        toMap(trip), MailType.DELETE);
+    Thread.sleep(5000);
+  }
+
+  @Test
+  void 여행_등록_실패_이메일_전송_테스트() throws InterruptedException {
+    tripEmailService.send("rlfrmsdh1@gmail.com",
+        toMap(trip), MailType.FAIL);
     Thread.sleep(5000);
   }
 }


### PR DESCRIPTION
<!-- PR 제목 양식 예시: [AIR-N] 회원 기능 도메인 -->

## 🛠️ 작업 내용
- 같은 email에 대해 여러 개의 인증키가 존재하여, 최신 인증키를 가져오도록 수정
- toMap 메서드 유틸리티 메서드로 구성
- 여행 예약 완료, 실패에 대한 메일 EventRunner에서 작동하도록 수정

## 🗨️ 기타
<!-- PR 포인트 혹은 궁금한 점 등등 적어주시면 됩니다. 없으시면 지워주세요 -->
-  EmailService와  추상 클래스, 그리고 구현체들에 대해서는 default 메서드를 추가하는 식으로 적용한 것이 그리 나쁘진 않아보여서 그대로 두었는데, 조금 더 나은 방법을 생각해보면 사실 MemberEmailService와 Trip, RoomEmailService를 인터페이스를 아예 따로 만들어 버리는 것이 더 낫겠다는 생각도 드네요..

- 으악 또 커져 버렸다.. PR;