### PR TITLE
[AIR-140] 회원 생성 유효성 검증 커맨드로 이동 

### DIFF
--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/member/entity/Member.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/member/entity/Member.java
@@ -1,15 +1,11 @@
 package com.gurudev.aircnc.domain.member.entity;
 
-import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
-import static com.gurudev.aircnc.exception.Preconditions.checkNotNull;
-import static org.springframework.util.StringUtils.hasText;
+import static javax.persistence.EnumType.STRING;
 
 import com.gurudev.aircnc.domain.base.BaseIdEntity;
 import java.time.LocalDate;
-import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -31,27 +27,21 @@ public class Member extends BaseIdEntity {
   @Embedded
   private Password password;
 
-  @Column(length = 20, nullable = false)
   private String name;
 
-  @Column(nullable = false)
   private LocalDate birthDate;
 
   @Embedded
   private PhoneNumber phoneNumber;
 
-  @Enumerated(value = EnumType.STRING)
-  @Column(nullable = false)
+  @Enumerated(value = STRING)
   private Role role;
 
   /**
    * 회원 가입시 사용되는 생성자 <br> 회원 가입을 위해 이메일, 비밀번호, 이름, 생년월일, 전화번호, 역할을 제공해야 한다.
    */
-
   public Member(Email email, Password password, String name, LocalDate birthDate,
       PhoneNumber phoneNumber, Role role) {
-    checkArgument(hasText(name), "이름은 공백이 될 수 없습니다");
-    checkNotNull(birthDate, "생일은 null 이 될 수 없습니다");
 
     this.email = email;
     this.name = name;

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/member/service/command/MemberCommand.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/member/service/command/MemberCommand.java
@@ -1,6 +1,9 @@
 package com.gurudev.aircnc.domain.member.service.command;
 
+import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
+import static com.gurudev.aircnc.exception.Preconditions.checkNotNull;
 import static lombok.AccessLevel.PRIVATE;
+import static org.springframework.util.StringUtils.hasText;
 
 import com.gurudev.aircnc.domain.member.entity.Email;
 import com.gurudev.aircnc.domain.member.entity.Member;
@@ -10,29 +13,40 @@ import com.gurudev.aircnc.domain.member.entity.Role;
 import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 public final class MemberCommand {
 
-  @RequiredArgsConstructor
   @Getter
   public static class MemberRegisterCommand {
 
-    private final String email;
-    private final String password;
+    private final Email email;
+    private final Password password;
     private final String name;
     private final LocalDate birthDate;
-    private final String phoneNumber;
-    private final String role;
+    private final PhoneNumber phoneNumber;
+    private final Role role;
+
+    public MemberRegisterCommand(String email, String password, String name,
+        LocalDate birthDate, String phoneNumber, String role) {
+
+      checkArgument(hasText(name), "이름은 공백이 될 수 없습니다");
+      checkNotNull(birthDate, "생일은 null 이 될 수 없습니다");
+
+      this.email = new Email(email);
+      this.password = new Password(password);
+      this.name = name;
+      this.birthDate = birthDate;
+      this.phoneNumber = new PhoneNumber(phoneNumber);
+      this.role = Role.valueOf(role);
+    }
+
+    public Password getPassword() {
+      return new Password(Password.toString(password));
+    }
 
     public Member toEntity() {
-      return new Member(
-          new Email(this.email), new Password(this.password),
-          this.name, this.birthDate,
-          new PhoneNumber(this.phoneNumber),
-          Role.valueOf(this.role));
+      return new Member(email, password, name, birthDate, phoneNumber, role);
     }
   }
-
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/MemberTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/entity/MemberTest.java
@@ -1,14 +1,11 @@
 package com.gurudev.aircnc.domain.member.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class MemberTest {
 
@@ -33,24 +30,9 @@ class MemberTest {
     //when
     Member member = new Member(email, password, name, birthDate, phoneNumber, Role.GUEST);
 
-    //tehn
+    //then
     assertThat(member).extracting(Member::getEmail, Member::getPassword, Member::getName,
             Member::getBirthDate, Member::getPhoneNumber)
         .isEqualTo(List.of(email, password, name, birthDate, phoneNumber));
-  }
-
-  @ParameterizedTest
-  @NullAndEmptySource
-  void 이름_공백_불가(String name) {
-    //then
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> new Member(email, password, name, birthDate, phoneNumber, Role.GUEST));
-  }
-
-  @Test
-  void 생일_null_불가() {
-    //then
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> new Member(email, password, name, null, phoneNumber, Role.GUEST));
   }
 }

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/command/MemberCommandTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/member/service/command/MemberCommandTest.java
@@ -1,0 +1,69 @@
+package com.gurudev.aircnc.domain.member.service.command;
+
+import static java.time.LocalDate.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.gurudev.aircnc.domain.member.entity.Email;
+import com.gurudev.aircnc.domain.member.entity.Password;
+import com.gurudev.aircnc.domain.member.entity.PhoneNumber;
+import com.gurudev.aircnc.domain.member.entity.Role;
+import com.gurudev.aircnc.domain.member.service.command.MemberCommand.MemberRegisterCommand;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class MemberCommandTest {
+
+  @Nested
+  class 회원_가입_명령 {
+
+    @Test
+    void 회원_가입_명령_생성_성공() {
+      //when
+      MemberRegisterCommand command
+          = new MemberRegisterCommand("ndy@haha.com", "paSSword!", "ndy", of(1997, 8, 21),
+          "010-1234-5678", "GUEST");
+
+      //then
+      assertThat(command).isNotNull()
+          .extracting(MemberRegisterCommand::getEmail,
+              MemberRegisterCommand::getPassword,
+              MemberRegisterCommand::getName,
+              MemberRegisterCommand::getBirthDate,
+              MemberRegisterCommand::getPhoneNumber,
+              MemberRegisterCommand::getRole)
+          .containsExactly(
+              new Email("ndy@haha.com"),
+              new Password("paSSword!"),
+              "ndy",
+              of(1997, 8, 21),
+              new PhoneNumber("010-1234-5678"),
+              Role.GUEST
+          );
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void 이름_공백_불가(String name) {
+      //then
+      assertThatIllegalArgumentException()
+          .isThrownBy(
+              () -> new MemberRegisterCommand("ndy@haha.com", "paSSword!", name, of(1997, 8, 21),
+                  "010-1234-5678", "GUEST"));
+    }
+
+    @Test
+    void 생일_null_불가() {
+      //given
+      LocalDate birthDate = null;
+
+      //then
+      assertThatIllegalArgumentException()
+          .isThrownBy(() -> new MemberRegisterCommand("ndy@haha.com", "paSSword!", "ndy", birthDate,
+              "010-1234-5678", "GUEST"));
+    }
+  }
+}

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/room/service/RoomServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
+import com.gurudev.aircnc.domain.member.entity.Email;
 import com.gurudev.aircnc.domain.member.entity.Member;
 import com.gurudev.aircnc.domain.member.service.MemberService;
 import com.gurudev.aircnc.domain.member.service.command.MemberCommand.MemberRegisterCommand;
@@ -74,7 +75,7 @@ class RoomServiceImplTest {
 
     // 가짜 회원 세팅
     MemberRegisterCommand fakeHostRegisterCommand = Command.ofRegisterMember(createHost());
-    ReflectionTestUtils.setField(fakeHostRegisterCommand, "email", "fakeHost@email.com");
+    ReflectionTestUtils.setField(fakeHostRegisterCommand, "email", new Email("fakeHost@email.com"));
     fakeHost = memberService.register(fakeHostRegisterCommand);
 
     //숙소의 필드 세팅


### PR DESCRIPTION
## 🛠️ 작업 내용
- 회원 생성 유효성 검증 커맨드로 이동 

- 저희가 커맨드까지 도입한 마당에 도메인 로직과 관계없어 보이는 간단한 유효성 검증로직 (hasText, 길이 체크 등)이 엔티티의 생성자에서 행해지는 것이 조금 맞지 않는것 같아 생성 커맨드로 옮겨보았습니다.

- `만들면서 배우는 클린 아키텍처 04장 유스케이스 구현하기 섹션 입력 유효성 검증 `을 참고하였습니다.

- 값 객체를 사용하는 경우와 사용하지 않는 경우 유효성 검증 시점이 통일 되는 장점이 있는것 같습니다.

- 회원에 대해서만 진행했습니다.
논의 해보고 괜찮으면 숙소, 여행에도 적용하고 그렇지 않다면 close 하겠습니다

