### PR TITLE
[AIR-143] 여행 유효성 검증 커맨드로 이동

### DIFF
--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/Trip.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/entity/Trip.java
@@ -3,7 +3,6 @@ package com.gurudev.aircnc.domain.trip.entity;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.CANCELLED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.RESERVED;
 import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
-import static java.time.LocalDate.now;
 import static java.time.Period.between;
 import static javax.persistence.EnumType.STRING;
 import static javax.persistence.FetchType.LAZY;
@@ -30,8 +29,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class Trip extends BaseIdEntity {
 
-  public static final int TRIP_TOTAL_PRICE_MIN_VALUE = 10000;
-
   @ManyToOne(fetch = LAZY)
   private Member guest;
 
@@ -51,16 +48,9 @@ public class Trip extends BaseIdEntity {
 
   public Trip(Member guest, Room room, LocalDate checkIn, LocalDate checkOut,
       int totalPrice, int headCount) {
-    checkArgument(checkOut.isAfter(checkIn), "체크아웃은 체크인 이전이 될 수 없습니다");
-    checkArgument(checkIn.isEqual(now()) || checkIn.isAfter(now()),
-        "체크인 날짜는" + now() + " 이전이 될 수 없습니다.");
 
-    checkArgument(totalPrice >= TRIP_TOTAL_PRICE_MIN_VALUE,
-        String.format("총 가격은 %d원 미만이 될 수 없습니다", TRIP_TOTAL_PRICE_MIN_VALUE));
     checkTotalPrice(checkIn, checkOut, totalPrice, room);
     checkHeadCount(headCount, room);
-
-    checkArgument(headCount >= 1, "인원은 1명 이상이여야 합니다");
 
     this.guest = guest;
     this.room = room;

--- a/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/service/command/TripCommand.java
+++ b/aircnc/src/main/java/com/gurudev/aircnc/domain/trip/service/command/TripCommand.java
@@ -1,5 +1,7 @@
 package com.gurudev.aircnc.domain.trip.service.command;
 
+import static com.gurudev.aircnc.exception.Preconditions.checkArgument;
+import static java.time.LocalDate.now;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.gurudev.aircnc.controller.dto.TripDto.TripReserveRequest;
@@ -15,6 +17,8 @@ public final class TripCommand {
   @Getter
   public static class TripReserveCommand {
 
+    public static final int TRIP_TOTAL_PRICE_MIN_VALUE = 10000;
+
     private Long guestId;
     private Long roomId;
     private LocalDate checkIn;
@@ -24,6 +28,15 @@ public final class TripCommand {
 
     public TripReserveCommand(Long guestId, Long roomId, LocalDate checkIn,
         LocalDate checkOut, int headCount, int totalPrice) {
+      checkArgument(checkOut.isAfter(checkIn), "체크아웃은 체크인 이전이 될 수 없습니다");
+      checkArgument(checkIn.isEqual(now()) || checkIn.isAfter(now()),
+          "체크인 날짜는" + now() + " 이전이 될 수 없습니다.");
+
+      checkArgument(totalPrice >= TRIP_TOTAL_PRICE_MIN_VALUE,
+          String.format("총 가격은 %d원 미만이 될 수 없습니다", TRIP_TOTAL_PRICE_MIN_VALUE));
+
+      checkArgument(headCount >= 1, "인원은 1명 이상이여야 합니다");
+
       this.guestId = guestId;
       this.roomId = roomId;
       this.checkIn = checkIn;

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/entity/TripTest.java
@@ -1,6 +1,5 @@
 package com.gurudev.aircnc.domain.trip.entity;
 
-import static com.gurudev.aircnc.domain.trip.entity.Trip.TRIP_TOTAL_PRICE_MIN_VALUE;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.CANCELLED;
 import static com.gurudev.aircnc.domain.trip.entity.TripStatus.RESERVED;
 import static com.gurudev.aircnc.domain.util.Fixture.createGuest;
@@ -57,35 +56,6 @@ class TripTest {
         .isEqualTo(List.of(guest, room, checkIn, checkOut, totalPrice, headCount, RESERVED));
   }
 
-  @Test
-  void CheckIn이_CheckOut_이전_이여야_한다() {
-    //given
-    LocalDate invalidCheckOut = checkIn.minusDays(1);
-
-    //then
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> new Trip(guest, room, checkIn, invalidCheckOut, totalPrice, headCount));
-  }
-
-  @Test
-  void 인원이_0명_이하_일_수_없다() {
-    //given
-    int invalidHeadCount = 0;
-
-    //then
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, totalPrice, invalidHeadCount));
-  }
-
-  @Test
-  void 총_가격은_제한가격_미만일_수_없다() {
-    //given
-    int invalidTotalPrice = TRIP_TOTAL_PRICE_MIN_VALUE - 1;
-
-    //then
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> new Trip(guest, room, checkIn, checkOut, invalidTotalPrice, headCount));
-  }
 
   @Test
   void 계산된_가격과_요청된_가격이_같아야_한다() {

--- a/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/command/TripCommandTest.java
+++ b/aircnc/src/test/java/com/gurudev/aircnc/domain/trip/service/command/TripCommandTest.java
@@ -1,0 +1,68 @@
+package com.gurudev.aircnc.domain.trip.service.command;
+
+
+import static com.gurudev.aircnc.domain.trip.service.command.TripCommand.TripReserveCommand.TRIP_TOTAL_PRICE_MIN_VALUE;
+import static java.time.LocalDate.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.gurudev.aircnc.domain.trip.service.command.TripCommand.TripReserveCommand;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TripCommandTest {
+
+  @Nested
+  class 여행_예약_명령 {
+
+    @Test
+    void 여행_예약_명령_생성_성공() {
+      //when
+      TripReserveCommand command =
+          new TripReserveCommand(1L, 2L, now(), now().plusDays(1L), 2, 10000
+          );
+
+      //then
+      assertThat(command).isNotNull()
+          .extracting(TripReserveCommand::getGuestId,
+              TripReserveCommand::getRoomId,
+              TripReserveCommand::getCheckIn,
+              TripReserveCommand::getCheckOut,
+              TripReserveCommand::getHeadCount,
+              TripReserveCommand::getTotalPrice)
+          .containsExactly(1L, 2L, now(), now().plusDays(1L), 2, 10000);
+    }
+
+    @Test
+    void CheckIn이_CheckOut_이전_이여야_한다() {
+      //given
+      LocalDate invalidCheckOut = now().minusDays(1);
+
+      //then
+      assertThatIllegalArgumentException().isThrownBy(() ->
+          new TripReserveCommand(1L, 2L, now(), invalidCheckOut, 2, 10000));
+    }
+
+    @Test
+    void 인원이_0명_이하_일_수_없다() {
+      //given
+      int invalidHeadCount = 0;
+
+      //then
+      assertThatIllegalArgumentException().isThrownBy(() ->
+          new TripReserveCommand(1L, 2L, now(), now().plusDays(1L), invalidHeadCount, 10000));
+    }
+
+    @Test
+    void 총_가격은_제한가격_미만일_수_없다() {
+      //given
+      int invalidTotalPrice = TRIP_TOTAL_PRICE_MIN_VALUE - 1;
+
+      //then
+      assertThatIllegalArgumentException().isThrownBy(() ->
+          new TripReserveCommand(1L, 2L, now(), now().plusDays(1L), 2, invalidTotalPrice));
+    }
+
+  }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
- 여행 유효성 검증 커맨드로 이동
- 숙소를 조회해야 하는 비즈니스 로직 검증인 
    - capacity 보다 headcount 가 작아야한다는 것과
    - 서버의 숙소의 값으로 계산된 가격이 요청받은 가격과 같아야 한다는 것 빼고는 모두 커맨드로 이동하였습니다.